### PR TITLE
More margin tests

### DIFF
--- a/contracts/interfaces/IPerpAccountModule.sol
+++ b/contracts/interfaces/IPerpAccountModule.sol
@@ -49,7 +49,9 @@ interface IPerpAccountModule {
         // @dev Position size
         int128 size;
         // @dev Initial margin requirement
-        uint256 initialMarginRequirement;
+        uint256 im;
+        // @dev Maintenance margin requirement
+        uint256 mm;
     }
 
     // --- Views --- //

--- a/contracts/interfaces/IPerpAccountModule.sol
+++ b/contracts/interfaces/IPerpAccountModule.sol
@@ -48,6 +48,8 @@ interface IPerpAccountModule {
         uint256 oraclePrice;
         // @dev Position size
         int128 size;
+        // @dev Initial margin requirement
+        uint256 initialMarginRequirement;
     }
 
     // --- Views --- //

--- a/contracts/interfaces/IPerpAccountModule.sol
+++ b/contracts/interfaces/IPerpAccountModule.sol
@@ -33,7 +33,7 @@ interface IPerpAccountModule {
         // @dev id of the market that was queried.
         uint128 marketId;
         // @dev Total remaining margin for position in USD.
-        uint256 marginUsd;
+        uint256 remainingMarginUsd;
         // @dev Health factor for position in market if a position is open.
         uint256 healthFactor;
         // @dev Notional value of position in USD.

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -34,10 +34,6 @@ contract MarginModule is IMarginModule {
 
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(market.id);
 
-        // Position is frozen due to prior flagged for liquidation.
-        if (market.flaggedLiquidations[accountId] != address(0)) {
-            revert ErrorUtil.PositionFlagged();
-        }
         // Ensure does not lead to instant liquidation.
         if (position.isLiquidatable(market, marginUsd, oraclePrice, marketConfig)) {
             revert ErrorUtil.CanLiquidatePosition();
@@ -151,6 +147,10 @@ contract MarginModule is IMarginModule {
         Order.Data storage order = market.orders[accountId];
         if (order.sizeDelta != 0) {
             revert ErrorUtil.OrderFound(accountId);
+        }
+        // Position is frozen due to prior flagged for liquidation.
+        if (market.flaggedLiquidations[accountId] != address(0)) {
+            revert ErrorUtil.PositionFlagged();
         }
 
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -251,8 +251,10 @@ contract MarginModule is IMarginModule {
 
             // Perform this operation _once_ when this collateral is added as a supported collateral.
             uint128 maxAllowable = maxAllowables[i];
-            IERC20(collateralType).approve(address(globalMarketConfig.synthetix), maxAllowable);
-            IERC20(collateralType).approve(address(this), maxAllowable);
+            uint256 maxUint = type(uint256).max;
+
+            IERC20(collateralType).approve(address(globalMarketConfig.synthetix), maxUint);
+            IERC20(collateralType).approve(address(this), maxUint);
             globalMarginConfig.supported[collateralType] = Margin.CollateralType(oracleNodeIds[i], maxAllowable);
             newSupportedAddresses[i] = collateralType;
 

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -114,11 +114,12 @@ contract MarginModule is IMarginModule {
         uint256 length = globalMarginConfig.supportedAddresses.length;
         address collateralType;
         uint256 available;
+        uint256 total;
 
         for (uint256 i = 0; i < length; i++) {
             collateralType = globalMarginConfig.supportedAddresses[i];
             available = accountMargin.collaterals[collateralType];
-
+            total += available;
             if (available == 0) {
                 continue;
             }
@@ -127,6 +128,9 @@ contract MarginModule is IMarginModule {
 
             // Withdraw all available collateral for this `collateralType`.
             withdrawAndTransfer(marketId, available, collateralType, globalConfig);
+        }
+        if (total == 0) {
+            revert ErrorUtil.NilCollateral();
         }
     }
 

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -104,8 +104,8 @@ contract MarginModule is IMarginModule {
         if (position.size != 0) {
             revert ErrorUtil.PositionFound(accountId, marketId);
         }
-        // (int256 fundingRate, ) = market.recomputeFunding(oraclePrice);
-        // emit FundingRecomputed(marketId, market.skew, fundingRate, market.getCurrentFundingVelocity());
+        (int256 fundingRate, ) = market.recomputeFunding(market.getOraclePrice());
+        emit FundingRecomputed(marketId, market.skew, fundingRate, market.getCurrentFundingVelocity());
 
         Margin.GlobalData storage globalMarginConfig = Margin.load();
         Margin.Data storage accountMargin = Margin.load(accountId, marketId);

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -34,6 +34,10 @@ contract MarginModule is IMarginModule {
 
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(market.id);
 
+        // Position is frozen due to prior flagged for liquidation.
+        if (market.flaggedLiquidations[accountId] != address(0)) {
+            revert ErrorUtil.PositionFlagged();
+        }
         // Ensure does not lead to instant liquidation.
         if (position.isLiquidatable(market, marginUsd, oraclePrice, marketConfig)) {
             revert ErrorUtil.CanLiquidatePosition();

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -94,6 +94,10 @@ contract MarginModule is IMarginModule {
         if (market.orders[accountId].sizeDelta != 0) {
             revert ErrorUtil.OrderFound(accountId);
         }
+        // Position is frozen due to prior flagged for liquidation.
+        if (market.flaggedLiquidations[accountId] != address(0)) {
+            revert ErrorUtil.PositionFlagged();
+        }
 
         // Prevent collateral transfers when there's an open position.
         Position.Data storage position = market.positions[accountId];

--- a/contracts/modules/PerpAccountModule.sol
+++ b/contracts/modules/PerpAccountModule.sol
@@ -65,14 +65,12 @@ contract PerpAccountModule is IPerpAccountModule {
         Position.Data storage position = market.positions[accountId];
 
         uint256 oraclePrice = market.getOraclePrice();
+        PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);
+
         (uint256 healthFactor, int256 accruedFunding, int256 unrealizedPnl, uint256 remainingMarginUsd) = position
-            .getHealthData(
-                market,
-                Margin.getMarginUsd(accountId, market, oraclePrice),
-                oraclePrice,
-                PerpMarketConfiguration.load(marketId)
-            );
+            .getHealthData(market, Margin.getMarginUsd(accountId, market, oraclePrice), oraclePrice, marketConfig);
         uint256 notionalValueUsd = MathUtil.abs(position.size).mulDecimal(oraclePrice);
+        (uint256 im, , ) = Position.getLiquidationMarginUsd(position.size, oraclePrice, marketConfig);
 
         return
             IPerpAccountModule.PositionDigest(
@@ -85,7 +83,8 @@ contract PerpAccountModule is IPerpAccountModule {
                 accruedFunding,
                 position.entryPrice,
                 oraclePrice,
-                position.size
+                position.size,
+                im
             );
     }
 }

--- a/contracts/modules/PerpAccountModule.sol
+++ b/contracts/modules/PerpAccountModule.sol
@@ -70,7 +70,7 @@ contract PerpAccountModule is IPerpAccountModule {
         (uint256 healthFactor, int256 accruedFunding, int256 unrealizedPnl, uint256 remainingMarginUsd) = position
             .getHealthData(market, Margin.getMarginUsd(accountId, market, oraclePrice), oraclePrice, marketConfig);
         uint256 notionalValueUsd = MathUtil.abs(position.size).mulDecimal(oraclePrice);
-        (uint256 im, , ) = Position.getLiquidationMarginUsd(position.size, oraclePrice, marketConfig);
+        (uint256 im, uint256 mm, ) = Position.getLiquidationMarginUsd(position.size, oraclePrice, marketConfig);
 
         return
             IPerpAccountModule.PositionDigest(
@@ -84,7 +84,8 @@ contract PerpAccountModule is IPerpAccountModule {
                 position.entryPrice,
                 oraclePrice,
                 position.size,
-                im
+                im,
+                mm
             );
     }
 }

--- a/contracts/storage/Position.sol
+++ b/contracts/storage/Position.sol
@@ -345,7 +345,8 @@ library Position {
         // Ensure we also deduct the realized losses in fees to open trade.
         //
         // The remaining margin is defined as sum(collateral * price) + PnL + funding in USD.
-        remainingMarginUsd = MathUtil.max(marginUsd.toInt() + pnl + accruedFunding, 0).toUint();
+        // We expect caller to have gotten this from Margin.getMarginUsd
+        remainingMarginUsd = marginUsd;
 
         // margin / mm <= 1 means liquidation.
         (, uint256 mm, ) = getLiquidationMarginUsd(positionSize, price, marketConfig);

--- a/contracts/utils/ErrorUtil.sol
+++ b/contracts/utils/ErrorUtil.sol
@@ -65,6 +65,9 @@ library ErrorUtil {
     // @dev Thrown when an account has insufficient collateral to transfer.
     error InsufficientCollateral(address collateral, uint256 available, uint256 value);
 
+    // @dev Thrown when an account tries to withdrawAll without having any collateral
+    error NilCollateral();
+
     // @dev Thrown when attempting to deposit a collateral that has reached a max deportable amount.
     error MaxCollateralExceeded(uint256 value, uint256 max);
 

--- a/test/assert.ts
+++ b/test/assert.ts
@@ -1,0 +1,62 @@
+import { Contract, ContractReceipt, ContractTransaction } from 'ethers';
+import assert from 'assert';
+import { LogDescription } from 'ethers/lib/utils';
+
+const formatDecodedArg = (value: LogDescription['args'][number]): string => {
+  // print nested values as [value1, value2, ...]
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatDecodedArg(v)).join(', ')}]`;
+  }
+
+  // surround string values with quotes
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+
+  return value.toString();
+};
+const formatDecodedArgs = (values: LogDescription['args']) => values.map((x) => formatDecodedArg(x)).join(', ');
+export const assertEvents = async (
+  tx: ContractTransaction | ContractReceipt,
+  expected: (string | RegExp)[],
+  contract: Contract
+) => {
+  const receipt = 'wait' in tx ? await tx.wait() : tx;
+  const spaces = ' '.repeat(6); // to align with assert output
+
+  const { logs } = receipt;
+  if (logs.length !== expected.length) {
+    throw new Error(`Expected ${expected.length} events, got ${logs.length}`);
+  }
+  let seenEvents: string[] = [];
+  const parsedLogs = logs.map((log, i) => {
+    try {
+      const parsed = contract.interface.parseLog(log);
+      const event = `${parsed.name}(${parsed.args ? formatDecodedArgs(parsed.args) : ''})`;
+      seenEvents.push(event);
+      return event;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse log at index: ${i} \n${spaces}List of parsed events:\n${spaces}${seenEvents.join(
+          `\n${spaces}`
+        )} \n${spaces}Ethers error: ${(error as any).message}`
+      );
+    }
+  });
+  parsedLogs.forEach((event, i) => {
+    const expectedAtIndex = expected[i];
+    if (typeof expectedAtIndex === 'string' ? event === expectedAtIndex : event.match(expectedAtIndex)) {
+      return;
+    } else {
+      const allEvents = parsedLogs.join(`\n${spaces}`);
+
+      typeof expectedAtIndex === 'string'
+        ? assert.strictEqual(
+            event,
+            expectedAtIndex,
+            `Event at index ${i} did not match. \n${spaces}List of parsed events:\n${spaces}${allEvents}`
+          )
+        : assert.match(event, expectedAtIndex);
+    }
+  });
+};

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,6 +7,7 @@ import { wei } from '@synthetixio/wei';
 import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import { isNil, uniq } from 'lodash';
 import assert from 'assert';
+
 // --- Constants --- //
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, utils } from 'ethers';
+import { BigNumber, Contract, ContractReceipt, ContractTransaction, utils } from 'ethers';
 import { LogLevel } from '@ethersproject/logger';
 import { PerpMarketConfiguration } from './generated/typechain/MarketConfigurationModule';
 import type { bootstrap } from './bootstrap';
@@ -6,7 +6,7 @@ import { type genTrader, type genOrder, genNumber } from './generators';
 import { wei } from '@synthetixio/wei';
 import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import { isNil, uniq } from 'lodash';
-
+import assert from 'assert';
 // --- Constants --- //
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -161,4 +161,62 @@ export const extendContractAbi = (contract: Contract, abi: string[]) => {
   );
   utils.Logger.setLogLevel(LogLevel.WARNING); // enable default logging again
   return newContract;
+};
+
+const formatDecodedArgs = (value: any): string => {
+  // print nested values as [value1, value2, ...]
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatDecodedArgs(v)).join(', ')}]`;
+  }
+
+  // surround string values with quotes
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+
+  return value.toString();
+};
+export const assertEvents = async (
+  tx: ContractTransaction | ContractReceipt,
+  expected: (string | RegExp)[],
+  contract: Contract
+) => {
+  const receipt = 'wait' in tx ? await tx.wait() : tx;
+  const spaces = ' '.repeat(6); // to align with assert output
+
+  const { logs } = receipt;
+  if (logs.length !== expected.length) {
+    throw new Error(`Expected ${expected.length} events, got ${logs.length}`);
+  }
+  let seenEvents: string[] = [];
+  const parsedLogs = logs.map((log, i) => {
+    try {
+      const parsed = contract.interface.parseLog(log);
+      const event = `${parsed.name}(${parsed.args ? formatDecodedArgs(parsed.args) : ''})`;
+      seenEvents.push(event);
+      return event;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse log at index: ${i} \n${spaces}List of parsed events:\n${spaces}${seenEvents.join(
+          `\n${spaces}`
+        )} \n${spaces}Ethers error: ${(error as any).message}`
+      );
+    }
+  });
+  parsedLogs.forEach((event, i) => {
+    const expectedAtIndex = expected[i];
+    if (typeof expectedAtIndex === 'string' ? event === expectedAtIndex : event.match(expectedAtIndex)) {
+      return;
+    } else {
+      const allEvents = parsedLogs.join(`\n${spaces}`);
+
+      typeof expectedAtIndex === 'string'
+        ? assert.strictEqual(
+            event,
+            expectedAtIndex,
+            `Event at index ${i} did not match. \n${spaces}List of parsed events:\n${spaces}${allEvents}`
+          )
+        : assert.match(event, expectedAtIndex);
+    }
+  });
 };

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -75,7 +75,7 @@ describe('MarginModule', async () => {
         collateral.contract.address,
         collateralDepositAmount2
       );
-      await assertEvent(tx, `FundingRecomputed()`, PerpMarketProxy);
+      await assertEvent(tx, `FundingRecomputed`, PerpMarketProxy);
     });
 
     it('should revert on modify when an order is pending', async () => {
@@ -997,8 +997,9 @@ describe('MarginModule', async () => {
       const collaterals = await PerpMarketProxy.getConfiguredCollaterals();
 
       assert.equal(collaterals.length, n);
-      let i = 0;
-      for (const collateral of collaterals) {
+
+      for (const [i, collateral] of Object.entries(collaterals)) {
+        const index = parseInt(i);
         const { maxAllowable, collateralType, oracleNodeId } = collateral;
         const collateralContract = new Contract(
           collateralType,
@@ -1010,10 +1011,9 @@ describe('MarginModule', async () => {
 
         assertBn.equal(ethers.constants.MaxUint256, perpsAllowance);
         assertBn.equal(ethers.constants.MaxUint256, coreAllowance);
-        assertBn.equal(maxAllowable, maxAllowables[i]);
-        assert.equal(collateralType, collateralTypes[i]);
-        assert.equal(oracleNodeId, oracleNodeIds[i]);
-        i++;
+        assertBn.equal(maxAllowable, maxAllowables[index]);
+        assert.equal(collateralType, collateralTypes[index]);
+        assert.equal(oracleNodeId, oracleNodeIds[index]);
       }
 
       await assertEvent(tx, `CollateralConfigured("${await from.getAddress()}", ${n})`, PerpMarketProxy);
@@ -1056,7 +1056,7 @@ describe('MarginModule', async () => {
       );
     });
 
-    it('should revoke/approve collateral with 0/maxUnit');
+    it('should revoke/approve collateral with 0/maxUint');
   });
 
   describe('getCollateralUsd', () => {

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -478,7 +478,34 @@ describe('MarginModule', async () => {
 
       it('should revert withdraw if places position into liquidation');
 
-      it('should revert when account is flagged for liquidation');
+      it('should revert when account is flagged for liquidation', async () => {
+        const { PerpMarketProxy } = systems();
+        const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(
+          bs,
+          genTrader(bs)
+        );
+        const order = await genOrder(bs, market, collateral, collateralDepositAmount, {
+          desiredSide: -1,
+          desiredLeverage: 10,
+        });
+        // open leveraged position
+        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        // updating price, causing position to be liquidatable
+        await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
+        // flag position
+        await PerpMarketProxy.flagPosition(trader.accountId, marketId);
+
+        await assertRevert(
+          PerpMarketProxy.connect(trader.signer).modifyCollateral(
+            trader.accountId,
+            marketId,
+            collateral.contract.address,
+            collateralDepositAmount.mul(-1)
+          ),
+          `PositionFlagged()`,
+          PerpMarketProxy
+        );
+      });
     });
 
     describe('withdrawAllCollateral', () => {

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -834,21 +834,10 @@ describe('MarginModule', async () => {
           genTrader(bs)
         );
 
-        // Create a new position.
-        await commitAndSettle(bs, marketId, trader, await genOrder(bs, market, collateral, collateralDepositAmount));
-
-        // Provision collateral and approve for access.
-        const { collateralDepositAmount: collateralDepositAmount2 } = await approveAndMintMargin(
-          bs,
-          genTrader(bs, { desiredMarket: market, desiredTrader: trader, desiredCollateral: collateral })
-        );
-
         // Perform the deposit.
-        const tx = await PerpMarketProxy.connect(trader.signer).modifyCollateral(
+        const tx = await PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(
           trader.accountId,
-          market.marketId(),
-          collateral.contract.address,
-          collateralDepositAmount2
+          market.marketId()
         );
         await assertEvent(tx, `FundingRecomputed()`, PerpMarketProxy);
       });

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../../generators';
 import { ZERO_ADDRESS, approveAndMintMargin, commitAndSettle, commitOrder, depositMargin } from '../../helpers';
 import { calcPnl } from '../../calculations';
+import assert from 'assert';
 
 describe('MarginModule', async () => {
   const bs = bootstrap(genBootstrap());
@@ -780,7 +781,14 @@ describe('MarginModule', async () => {
         await assertEvent(tx, `FundingRecomputed()`, PerpMarketProxy);
       });
 
-      it('should noop when account has no collateral to withdraw');
+      it('should noop when account has no collateral to withdraw', async () => {
+        const { PerpMarketProxy } = systems();
+        const { trader, marketId, collateral, market, collateralDepositAmount } = await genTrader(bs);
+
+        const tx = await PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(trader.accountId, marketId);
+        const { logs } = await tx.wait();
+        assert.equal(logs.length, 0);
+      });
 
       it('should revert when account does not exist', async () => {
         const { PerpMarketProxy } = systems();

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -846,13 +846,15 @@ describe('MarginModule', async () => {
         await assertEvent(tx, `FundingRecomputed()`, PerpMarketProxy);
       });
 
-      it('should noop when account has no collateral to withdraw', async () => {
+      it('should revert when account has no collateral to withdraw', async () => {
         const { PerpMarketProxy } = systems();
-        const { trader, marketId, collateral, market, collateralDepositAmount } = await genTrader(bs);
+        const { trader, marketId } = await genTrader(bs);
 
-        const tx = await PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(trader.accountId, marketId);
-        const { logs } = await tx.wait();
-        assert.equal(logs.length, 0);
+        await assertRevert(
+          PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(trader.accountId, marketId),
+          `NilCollateral()`,
+          PerpMarketProxy
+        );
       });
 
       it('should revert when account does not exist', async () => {

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -535,14 +535,17 @@ describe('MarginModule', async () => {
           marketId
         );
         const maxWithdrawUsd = wei(remainingMarginUsd).sub(initialMarginRequirement);
-        const maxWithdraw = maxWithdrawUsd.div(collateralPrice);
+        // Try withdrawing $10 more than max withdraw
+        const amountToWithdrawUsd = maxWithdrawUsd.add(10);
+        // Convert to native units
+        const amountToWithdraw = amountToWithdrawUsd.div(collateralPrice);
 
         await assertRevert(
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
             collateral.contract.address,
-            maxWithdraw.mul(-1).toBN()
+            amountToWithdraw.mul(-1).toBN()
           ),
           `InsufficientMargin()`,
           PerpMarketProxy
@@ -585,8 +588,8 @@ describe('MarginModule', async () => {
         });
         // open leveraged position
         await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
-        // Change price to make position liquidatable
-        await collateral.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
+        // Change market price to make position liquidatable
+        await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
 
         await assertRevert(
           PerpMarketProxy.connect(trader.signer).modifyCollateral(

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -523,12 +523,9 @@ describe('MarginModule', async () => {
           })
         );
 
-        const { initialMarginRequirement, remainingMarginUsd } = await PerpMarketProxy.getPositionDigest(
-          trader.accountId,
-          marketId
-        );
+        const { im, remainingMarginUsd } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
         // Figure out max withdraw
-        const maxWithdrawUsd = wei(remainingMarginUsd).sub(initialMarginRequirement);
+        const maxWithdrawUsd = wei(remainingMarginUsd).sub(im);
         const maxWithdraw = maxWithdrawUsd.div(collateralPrice);
         // Withdraw 90% of max withdraw
         const withdrawAmount = maxWithdraw.mul(0.9);
@@ -658,11 +655,8 @@ describe('MarginModule', async () => {
         // open leveraged position
         await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
 
-        const { initialMarginRequirement, remainingMarginUsd } = await PerpMarketProxy.getPositionDigest(
-          trader.accountId,
-          marketId
-        );
-        const maxWithdrawUsd = wei(remainingMarginUsd).sub(initialMarginRequirement);
+        const { im, remainingMarginUsd } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
+        const maxWithdrawUsd = wei(remainingMarginUsd).sub(im);
 
         // Try withdrawing $1 more than max withdraw
         const amountToWithdrawUsd = maxWithdrawUsd.add(1);

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -998,7 +998,23 @@ describe('MarginModule', async () => {
       assertBn.near(await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId), marginUsdDepositAmount);
     });
 
-    it('should return correct usd amount after price of collateral changes');
+    it('should return correct usd amount after price of collateral changes', async () => {
+      const { PerpMarketProxy } = systems();
+      const { trader, marketId, marginUsdDepositAmount, collateral, collateralPrice } = await depositMargin(
+        bs,
+        genTrader(bs)
+      );
+
+      assertBn.near(await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId), marginUsdDepositAmount);
+
+      // Change price
+      await collateral.aggregator().mockSetCurrentPrice(wei(2).mul(collateralPrice).toBN());
+
+      assertBn.near(
+        await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId),
+        wei(marginUsdDepositAmount).mul(2).toBN()
+      );
+    });
 
     it('should return zero when collateral has not been deposited', async () => {
       const { PerpMarketProxy } = systems();

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -565,8 +565,9 @@ describe('MarginModule', async () => {
           marketId
         );
         const maxWithdrawUsd = wei(remainingMarginUsd).sub(initialMarginRequirement);
-        // Try withdrawing $10 more than max withdraw
-        const amountToWithdrawUsd = maxWithdrawUsd.add(10);
+
+        // Try withdrawing $1 more than max withdraw
+        const amountToWithdrawUsd = maxWithdrawUsd.add(1);
         // Convert to native units
         const amountToWithdraw = amountToWithdrawUsd.div(collateralPrice);
 

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -20,7 +20,6 @@ import {
 import {
   ZERO_ADDRESS,
   approveAndMintMargin,
-  assertEvents,
   commitAndSettle,
   commitOrder,
   depositMargin,
@@ -28,6 +27,7 @@ import {
 } from '../../helpers';
 import { calcPnl } from '../../calculations';
 import { CollateralMock } from '../../../typechain-types';
+import { assertEvents } from '../../assert';
 
 describe('MarginModule', async () => {
   const bs = bootstrap(genBootstrap());
@@ -213,10 +213,10 @@ describe('MarginModule', async () => {
           tx,
           [
             /FundingRecomputed/,
-            `Transfer(["${traderAddress}", "${PerpMarketProxy.address}", ${collateralDepositAmount}])`, // from collateral ERC20 contract
-            `Transfer(["${PerpMarketProxy.address}", "${Core.address}", ${collateralDepositAmount}])`, // from collateral ERC20 contract
-            `MarketCollateralDeposited([${marketId}, "${collateral.contract.address}", ${collateralDepositAmount}, "${PerpMarketProxy.address}"])`, // from core
-            `MarginDeposit(["${traderAddress}", "${PerpMarketProxy.address}", ${collateralDepositAmount}, "${collateral.contract.address}"])`,
+            `Transfer("${traderAddress}", "${PerpMarketProxy.address}", ${collateralDepositAmount})`, // from collateral ERC20 contract
+            `Transfer("${PerpMarketProxy.address}", "${Core.address}", ${collateralDepositAmount})`, // from collateral ERC20 contract
+            `MarketCollateralDeposited(${marketId}, "${collateral.contract.address}", ${collateralDepositAmount}, "${PerpMarketProxy.address}")`, // from core
+            `MarginDeposit("${traderAddress}", "${PerpMarketProxy.address}", ${collateralDepositAmount}, "${collateral.contract.address}")`,
           ],
           contractsWithAllEvents
         );
@@ -471,10 +471,10 @@ describe('MarginModule', async () => {
           tx,
           [
             /FundingRecomputed/,
-            `Transfer(["${Core.address}", "${PerpMarketProxy.address}", ${withdrawAmount}])`, // from collateral ERC20 contract
-            `MarketCollateralWithdrawn([${marketId}, "${collateral.contract.address}", ${withdrawAmount}, "${PerpMarketProxy.address}"])`, // from core
-            `Transfer(["${PerpMarketProxy.address}", "${traderAddress}", ${withdrawAmount}])`, // from collateral ERC20 contract
-            `MarginWithdraw(["${PerpMarketProxy.address}", "${traderAddress}", ${withdrawAmount}, "${collateral.contract.address}"])`,
+            `Transfer("${Core.address}", "${PerpMarketProxy.address}", ${withdrawAmount})`, // from collateral ERC20 contract
+            `MarketCollateralWithdrawn(${marketId}, "${collateral.contract.address}", ${withdrawAmount}, "${PerpMarketProxy.address}")`, // from core
+            `Transfer("${PerpMarketProxy.address}", "${traderAddress}", ${withdrawAmount})`, // from collateral ERC20 contract
+            `MarginWithdraw("${PerpMarketProxy.address}", "${traderAddress}", ${withdrawAmount}, "${collateral.contract.address}")`,
           ],
           contractsWithAllEvents
         );

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -784,8 +784,9 @@ describe('OrderModule', () => {
       // Collect some data
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
 
-      // Using size to simulate short which will reduce the skew
-      const size = wei(genNumber(-10, -1)).toBN();
+      const prevPositionSizeNeg = wei(order.sizeDelta).mul(-1).toNumber();
+      // Using size to simulate short which will reduce the skew. The smallest negative size is the size of the current skew
+      const size = wei(genNumber(prevPositionSizeNeg, -1)).toBN();
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
 


### PR DESCRIPTION
Mostly tests. 

Functionality changes:
- Calculating margin by deducting fees + accrued funding + pnl twice
- Make sure we cant modifyCollateral or withdrawAll when flagged
- Include initialMarginRequirement in position digest
- Make sure funding is recomputed when interacting with collateral
- Perps and Core router approvals for collaterals should be maxUint
- withdrawAll should revert if user missing collateral