### PR TITLE
Test/funding

### DIFF
--- a/contracts/interfaces/IPerpMarketFactoryModule.sol
+++ b/contracts/interfaces/IPerpMarketFactoryModule.sol
@@ -18,6 +18,11 @@ interface IPerpMarketFactoryModule is IMarket {
         int128 skew;
         uint128 size;
         uint256 oraclePrice;
+        // TODO: Consistent naming here please.
+        //
+        // fundingVelocity, fundingRateVelocity, currentFundingRateVelocity, currentFundingVelocity
+        // currentFundingRate, fundingRate
+        // ???
         int256 fundingVelocity;
         int256 currentFundingRate;
         uint256 lastLiquidationTime;

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -48,6 +48,8 @@ contract OrderModule is IOrderModule {
         }
 
         uint256 oraclePrice = market.getOraclePrice();
+
+        // TODO: Consider removing and only recomputing funding at the settlement.
         recomputeFunding(market, oraclePrice);
 
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);

--- a/contracts/modules/PerpMarketFactoryModule.sol
+++ b/contracts/modules/PerpMarketFactoryModule.sol
@@ -90,7 +90,7 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
             return 0;
         }
         uint256 oraclePrice = market.getOraclePrice();
-        int256 priceWithFunding = int(oraclePrice) + market.getNextFunding(oraclePrice);
+        int256 priceWithFunding = int(oraclePrice) + market.getNextFundingAccrued(oraclePrice);
         int256 totalDebt = market.skew.mulDecimal(priceWithFunding) + market.debtCorrection;
         return MathUtil.max(totalDebt, 0).toUint();
     }

--- a/contracts/storage/Order.sol
+++ b/contracts/storage/Order.sol
@@ -100,9 +100,7 @@ library Order {
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
 
         uint256 ethPrice = globalConfig.oracleManager.process(globalConfig.ethOracleNodeId).price.toUint();
-        uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
-            (globalConfig.keeperSettlementGasUnits * block.basefee * 1e18) / 1e9
-        );
+        uint256 baseKeeperFeeUsd = ethPrice.mulDecimal((globalConfig.keeperSettlementGasUnits * block.basefee * 1e9));
         uint256 baseKeeperFeePlusProfitUsd = baseKeeperFeeUsd.mulDecimal(
             DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent
         ) + keeperFeeBufferUsd;

--- a/contracts/storage/Order.sol
+++ b/contracts/storage/Order.sol
@@ -29,11 +29,11 @@ library Order {
      * @dev See IOrderModule.fillPrice
      */
     function getFillPrice(int128 skew, uint128 skewScale, int128 size, uint256 price) internal pure returns (uint256) {
-        // Calculate pd (premium/discount) before and after trade
+        // Calculate pd (premium/discount) before and after trade.
         int256 pdBefore = skew.divDecimal(skewScale.toInt());
         int256 pdAfter = (skew + size).divDecimal(skewScale.toInt());
 
-        // Calculate price before and after trade with pd applied
+        // Calculate price before and after trade with pd applied.
         int256 priceBefore = price.toInt() + (price.toInt().mulDecimal(pdBefore));
         int256 priceAfter = price.toInt() + (price.toInt().mulDecimal(pdAfter));
 
@@ -97,12 +97,14 @@ library Order {
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
 
         uint256 ethPrice = globalConfig.oracleManager.process(globalConfig.ethOracleNodeId).price.toUint();
-        uint256 baseKeeperFeeUsd = globalConfig.keeperSettlementGasUnits * block.basefee * ethPrice;
-        uint256 boundedKeeperFeeUsd = MathUtil.max(
-            MathUtil.min(
-                globalConfig.minKeeperFeeUsd,
-                baseKeeperFeeUsd * (DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent) + keeperFeeBufferUsd
-            ),
+        uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
+            (globalConfig.keeperSettlementGasUnits * block.basefee * 1e18) / 1e9
+        );
+        uint256 baseKeeperFeePlusProfitUsd = baseKeeperFeeUsd.mulDecimal(
+            DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent
+        ) + keeperFeeBufferUsd;
+        uint256 boundedKeeperFeeUsd = MathUtil.min(
+            MathUtil.max(globalConfig.minKeeperFeeUsd, baseKeeperFeePlusProfitUsd),
             globalConfig.maxKeeperFeeUsd
         );
         return boundedKeeperFeeUsd;

--- a/contracts/storage/Order.sol
+++ b/contracts/storage/Order.sol
@@ -29,16 +29,19 @@ library Order {
      * @dev See IOrderModule.fillPrice
      */
     function getFillPrice(int128 skew, uint128 skewScale, int128 size, uint256 price) internal pure returns (uint256) {
+        int256 ss = skewScale.toInt();
+        int256 p = price.toInt();
+
         // Calculate pd (premium/discount) before and after trade.
-        int256 pdBefore = skew.divDecimal(skewScale.toInt());
-        int256 pdAfter = (skew + size).divDecimal(skewScale.toInt());
+        int256 pdBefore = skew.divDecimal(ss);
+        int256 pdAfter = (skew + size).divDecimal(ss);
 
         // Calculate price before and after trade with pd applied.
-        int256 priceBefore = price.toInt() + (price.toInt().mulDecimal(pdBefore));
-        int256 priceAfter = price.toInt() + (price.toInt().mulDecimal(pdAfter));
+        int256 pBefore = p + p.mulDecimal(pdBefore);
+        int256 pAfter = p + p.mulDecimal(pdAfter);
 
-        // fillPrice is the average of those prices.
-        return (priceBefore + priceAfter).toUint().divDecimal(DecimalMath.UNIT * 2);
+        // `fillPrice` is the average of those prices.
+        return (pBefore + pAfter).toUint().divDecimal(DecimalMath.UNIT * 2);
     }
 
     /**

--- a/contracts/storage/PerpMarket.sol
+++ b/contracts/storage/PerpMarket.sol
@@ -150,7 +150,7 @@ library PerpMarket {
         uint256 price
     ) internal returns (int256 fundingRate, int256 fundingAccrued) {
         fundingRate = getCurrentFundingRate(self);
-        fundingAccrued = getNextFunding(self, price);
+        fundingAccrued = getNextFundingAccrued(self, price);
 
         self.currentFundingRateComputed = fundingRate;
         self.currentFundingAccruedComputed = fundingAccrued;
@@ -258,7 +258,7 @@ library PerpMarket {
     /**
      * @dev Returns the next market funding accrued value.
      */
-    function getNextFunding(PerpMarket.Data storage self, uint256 price) internal view returns (int256) {
+    function getNextFundingAccrued(PerpMarket.Data storage self, uint256 price) internal view returns (int256) {
         int256 fundingRate = getCurrentFundingRate(self);
         // The minus sign is needed as funding flows in the opposite direction to skew.
         int256 avgFundingRate = -(self.currentFundingRateComputed + fundingRate).divDecimal(

--- a/contracts/storage/PerpMarket.sol
+++ b/contracts/storage/PerpMarket.sol
@@ -198,10 +198,7 @@ library PerpMarket {
      */
     function getCurrentFundingVelocity(PerpMarket.Data storage self) internal view returns (int256) {
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(self.id);
-
-        int128 maxFundingVelocity = marketConfig.maxFundingVelocity.toInt();
         int128 skewScale = marketConfig.skewScale.toInt();
-        int128 skew = self.skew;
 
         // Avoid a panic due to div by zero. Return 0 immediately.
         if (skewScale == 0) {
@@ -209,12 +206,13 @@ library PerpMarket {
         }
 
         // Ensures the proportionalSkew is between -1 and 1.
-        int256 pSkew = skew.divDecimal(skewScale);
+        int256 pSkew = self.skew.divDecimal(skewScale);
         int256 pSkewBounded = MathUtil.min(
             MathUtil.max(-(DecimalMath.UNIT).toInt(), pSkew),
             (DecimalMath.UNIT).toInt()
         );
-        return pSkewBounded.mulDecimal(maxFundingVelocity);
+
+        return pSkewBounded.mulDecimal(marketConfig.maxFundingVelocity.toInt());
     }
 
     /**

--- a/contracts/storage/Position.sol
+++ b/contracts/storage/Position.sol
@@ -336,7 +336,7 @@ library Position {
         uint256 price,
         PerpMarketConfiguration.Data storage marketConfig
     ) internal view returns (uint256 healthFactor, int256 accruedFunding, int256 pnl, uint256 remainingMarginUsd) {
-        int256 netFundingPerUnit = market.getNextFunding(price) - positionEntryFundingAccrued;
+        int256 netFundingPerUnit = market.getNextFundingAccrued(price) - positionEntryFundingAccrued;
         accruedFunding = positionSize.mulDecimal(netFundingPerUnit);
 
         // Calculate this position's PnL
@@ -428,7 +428,7 @@ library Position {
         if (self.size == 0) {
             return 0;
         }
-        return self.size.mulDecimal(market.getNextFunding(price) - self.entryFundingAccrued);
+        return self.size.mulDecimal(market.getNextFundingAccrued(price) - self.entryFundingAccrued);
     }
 
     // --- Member (mutative) --- //

--- a/test/calculations.ts
+++ b/test/calculations.ts
@@ -2,16 +2,15 @@ import { BigNumber } from 'ethers';
 import Wei, { wei } from '@synthetixio/wei';
 import type { Bs } from './typed';
 
-// --- Calculate pnl --- //
+/** Calculates a position's unrealised PnL (no funding or fees) given the current and previous price. */
 export const calcPnl = (size: BigNumber, currentPrice: BigNumber, previousPrice: BigNumber) =>
   wei(size).mul(wei(currentPrice).sub(previousPrice)).toBN();
 
-// Calculates PD
-const calcPD = (skew: Wei, skewScale: Wei) => skew.div(skewScale);
-// Calculates the price with pd applied
-const calcAdjustedPrice = (price: Wei, pd: Wei) => price.add(price.mul(pd));
-// Calculates fillPrice
+/** Calculates the fillPrice (pd adjusted market price) given market params and the size of next order. */
 export const calcFillPrice = (skew: BigNumber, skewScale: BigNumber, size: BigNumber, price: BigNumber) => {
+  const calcPD = (skew: Wei, skewScale: Wei) => skew.div(skewScale);
+  const calcAdjustedPrice = (price: Wei, pd: Wei) => price.add(price.mul(pd));
+
   if (skewScale.eq(0)) {
     return price;
   }

--- a/test/calculations.ts
+++ b/test/calculations.ts
@@ -23,6 +23,9 @@ export const calcFillPrice = (skew: BigNumber, skewScale: BigNumber, size: BigNu
   return priceBefore.add(priceAfter).div(2).toBN();
 };
 
+/** Calculates whether two numbers are the same sign. */
+export const isSameSide = (a: Wei | BigNumber, b: Wei | BigNumber) => a.eq(0) || b.eq(0) || a.gt(0) == b.gt(0);
+
 /** Calculates order fees and keeper fees associated to settle the order. */
 export const calcOrderFees = async (
   bs: Bs,
@@ -40,8 +43,6 @@ export const calcOrderFees = async (
   const fillPrice = await PerpMarketProxy.getFillPrice(marketId, sizeDelta);
   const { skew } = await PerpMarketProxy.getMarketDigest(marketId);
   const { makerFee, takerFee } = await PerpMarketProxy.getMarketConfigurationById(marketId);
-
-  const isSameSide = (a: Wei | BigNumber, b: Wei | BigNumber) => a.eq(0) || b.eq(0) || a.gt(0) == b.gt(0);
 
   let [makerSizeRatio, takerSizeRatio] = [wei(0), wei(0)];
   const marketSkewBefore = wei(skew);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,7 +10,8 @@ import { isNil, uniq } from 'lodash';
 // --- Constants --- //
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-export const ONE_DAY_IN_SEC = 60 * 60 * 24;
+export const SECONDS_ONE_HR = 60 * 60;
+export const SECONDS_ONE_DAY = SECONDS_ONE_HR * 24;
 
 // --- Mutative helpers --- //
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@ import { BigNumber, Contract, utils } from 'ethers';
 import { LogLevel } from '@ethersproject/logger';
 import { PerpMarketConfiguration } from './generated/typechain/MarketConfigurationModule';
 import type { bootstrap } from './bootstrap';
-import { type genOrder, type genTrader, genNumber } from './generators';
+import { type genTrader, type genOrder, genNumber } from './generators';
 import { wei } from '@synthetixio/wei';
 import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import { isNil, uniq } from 'lodash';

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,6 +10,7 @@ import { isNil, uniq } from 'lodash';
 // --- Constants --- //
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const ONE_DAY_IN_SEC = 60 * 60 * 24;
 
 // --- Mutative helpers --- //
 

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -1054,14 +1054,14 @@ describe('MarginModule', async () => {
   });
 
   describe('getCollateralUsd', () => {
-    it('should return correct usd amount in collateral', async () => {
+    it('should return the usd amount in collateral', async () => {
       const { PerpMarketProxy } = systems();
       const { trader, marketId, marginUsdDepositAmount } = await depositMargin(bs, genTrader(bs));
 
       assertBn.near(await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId), marginUsdDepositAmount);
     });
 
-    it('should return correct usd amount after price of collateral changes', async () => {
+    it('should return usd amount after price of collateral changes', async () => {
       const { PerpMarketProxy } = systems();
       const { trader, marketId, marginUsdDepositAmount, collateral, collateralPrice } = await depositMargin(
         bs,

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -60,7 +60,7 @@ describe('MarginModule', async () => {
       const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, genTrader(bs));
 
       // Create a new position.
-      await commitAndSettle(bs, marketId, trader, await genOrder(bs, market, collateral, collateralDepositAmount));
+      await commitAndSettle(bs, marketId, trader, genOrder(bs, market, collateral, collateralDepositAmount));
 
       // Provision collateral and approve for access.
       const { collateralDepositAmount: collateralDepositAmount2 } = await approveAndMintMargin(
@@ -399,7 +399,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 10,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
         // updating price, causing position to be liquidatable
         await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
         // flag position
@@ -653,7 +653,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 5,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
 
         const { im, remainingMarginUsd } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
         const maxWithdrawUsd = wei(remainingMarginUsd).sub(im);
@@ -686,7 +686,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 10,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
 
         await assertRevert(
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
@@ -710,7 +710,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 10,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
         // Change market price to make position liquidatable
         await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
 
@@ -737,7 +737,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 10,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
         // updating price, causing position to be liquidatable
         await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
         // flag position
@@ -899,7 +899,7 @@ describe('MarginModule', async () => {
           bs,
           genTrader(bs)
         );
-        await commitAndSettle(bs, marketId, trader, await genOrder(bs, market, collateral, collateralDepositAmount));
+        await commitAndSettle(bs, marketId, trader, genOrder(bs, market, collateral, collateralDepositAmount));
 
         // Perform withdraw with invalid market
         await assertRevert(
@@ -943,7 +943,7 @@ describe('MarginModule', async () => {
           desiredLeverage: 10,
         });
         // open leveraged position
-        await commitAndSettle(bs, marketId, trader, Promise.resolve(order));
+        await commitAndSettle(bs, marketId, trader, order);
         // updating price, causing position to be liquidatable
         await market.aggregator().mockSetCurrentPrice(wei(order.oraclePrice).mul(2).toBN());
         // flag position

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -775,8 +775,8 @@ describe('OrderModule', () => {
 
         const BLOCK_BASE_FEE_PER_GAS = 10;
 
-        // Set a really high ETH price of 10k USD.
-        await ethOracleNode().agg.mockSetCurrentPrice(wei(4850).toBN());
+        // Set a really high ETH price of 4.9k USD (Dec 21' ATH).
+        await ethOracleNode().agg.mockSetCurrentPrice(wei(4900).toBN());
 
         // Cap the max keeperFee to $50 USD
         const maxKeeperFeeUsd = wei(50).toBN();

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -860,23 +860,23 @@ describe('OrderModule', () => {
     it('should give premium when increasing skew', async () => {
       const { PerpMarketProxy } = systems();
 
-      const gTrader = genTrader(bs);
+      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, genTrader(bs));
 
-      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, gTrader);
-      // Creating a long skew for the market
+      // Creating a long skew for the market.
       const order = await genOrder(bs, market, collateral, collateralDepositAmount, {
         desiredLeverage: 1.1,
         desiredSide: 1,
       });
       await commitAndSettle(bs, marketId, trader, order);
 
-      // Collect some data
+      // Collect some data.
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
 
-      // Using size to simulate short which will reduce the skew
+      // Using size to simulate short which will reduce the skew.
       const size = wei(genNumber(1, 10)).toBN();
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
+
       // To get a "premium" to our long we expect the price to have a premium
       assertBn.gt(actualFillPrice, oraclePrice);
     });
@@ -884,20 +884,20 @@ describe('OrderModule', () => {
     it('should give discount when reducing skew', async () => {
       const { PerpMarketProxy } = systems();
 
-      const gTrader = genTrader(bs);
+      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, genTrader(bs));
 
-      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, gTrader);
-      // Creating a long skew for the market
+      // Creating a long skew for the market.
       const order = await genOrder(bs, market, collateral, collateralDepositAmount, {
         desiredLeverage: 10,
         desiredSide: 1,
       });
       await commitAndSettle(bs, marketId, trader, order);
 
-      // Collect some data
+      // Collect some data.
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
 
       const prevPositionSizeNeg = wei(order.sizeDelta).mul(-1).toNumber();
+
       // Using size to simulate short which will reduce the skew. The smallest negative size is the size of the current skew
       const size = wei(genNumber(prevPositionSizeNeg, -1)).toBN();
 
@@ -910,43 +910,40 @@ describe('OrderModule', () => {
     it('should return mark price as fillPrice when size is 0', async () => {
       const { PerpMarketProxy } = systems();
 
-      const gTrader = genTrader(bs);
-
-      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, gTrader);
+      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, genTrader(bs));
       const order = await genOrder(bs, market, collateral, collateralDepositAmount, { desiredLeverage: 1.1 });
 
       await commitAndSettle(bs, marketId, trader, order);
 
-      // Collect some data
+      // Collect some data.
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
       const { skewScale } = await PerpMarketProxy.getMarketConfigurationById(marketId);
       const marketSkew = order.sizeDelta;
 
-      // Size to check fill price
+      // Size to check fill price.
       const size = wei(0).toBN();
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
       const expectedFillPrice = wei(1).add(wei(marketSkew).div(skewScale)).mul(oraclePrice).toBN();
-      // Using near to avoid rounding errors
+
+      // Using near to avoid rounding errors.
       assertBn.near(expectedFillPrice, actualFillPrice);
     });
 
     it('should calculate fillPrice (exhaustive)', async () => {
       const { PerpMarketProxy } = systems();
 
-      const gTrader = genTrader(bs);
-
-      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, gTrader);
+      const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(bs, genTrader(bs));
       const order = await genOrder(bs, market, collateral, collateralDepositAmount, { desiredLeverage: 1.1 });
 
       await commitAndSettle(bs, marketId, trader, order);
 
-      // Collect some data
+      // Collect some data.
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
       const { skewScale } = await PerpMarketProxy.getMarketConfigurationById(marketId);
       const marketSkew = order.sizeDelta;
 
-      // Size to check fill price
+      // Size to check fill price.
       const size = wei(genNumber(-10, 10)).toBN();
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);

--- a/test/integration/modules/PerpAccountModule.test.ts
+++ b/test/integration/modules/PerpAccountModule.test.ts
@@ -1,0 +1,11 @@
+describe('PerpAccountModule', () => {
+  describe('getPositionDigest', () => {
+    describe('accruedFunding', () => {
+      it('should accrue funding when position is opposite of skew');
+
+      it('should pay funding when position is same side as skew');
+
+      it('should accrue or pay funding when size is 0');
+    });
+  });
+});

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -342,7 +342,7 @@ describe('PerpMarketFactoryModule', () => {
       });
 
       forEach(['long', 'short']).it(
-        'should continue to increase funding in same direction so long as market is skewed',
+        'should continue to increase (%s) funding in same direction insofar as market is skewed',
         async (side: string) => {
           const { PerpMarketProxy } = systems();
 

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import forEach from 'mocha-each';
 import { bootstrap } from '../../bootstrap';
 import { genAddress, genBootstrap, genBytes32 } from '../../generators';
 
@@ -72,6 +73,26 @@ describe('PerpMarketFactoryModule', () => {
         PerpMarketProxy.connect(from).setEthOracleNodeId(nodeId),
         `Unauthorized("${await from.getAddress()}")`
       );
+    });
+  });
+
+  describe('getMarketDigest', () => {
+    describe('{currentFundingRate,fundingVelocity}', () => {
+      it('should compute current funding rate relative to time (concrete)');
+
+      it('should demonstrate a balance market not having zero funding');
+
+      it('should have zero funding when market is new and empty');
+
+      it('should continue to increase funding in same direction so long as market is skewed');
+
+      it('should stop increasing funding when market perfectly balanced');
+
+      it('should change funding direction when skew flips');
+
+      it('should cap velocity by maxFundingVelocity');
+
+      // forEach([1, -1]).it('should result in max funding velocity when skew is 100% ({0})', async (side: number) => {});
     });
   });
 });

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -121,7 +121,7 @@ describe('PerpMarketFactoryModule', () => {
         await fastForwardTo((await provider().getBlock('latest')).timestamp + seconds, provider());
 
       it('should compute current funding rate relative to time (concrete)', async () => {
-        // This test is pulled directly from a conrete example developed for PerpsV2.
+        // This test is pulled directly from a concrete example developed for PerpsV2.
         //
         // @see: https://github.com/davidvuong/perpsv2-funding/blob/master/main.ipynb
         // @see: https://github.com/Synthetixio/synthetix/blob/develop/test/contracts/PerpsV2Market.js#L3631

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -1,12 +1,25 @@
 import assert from 'assert';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import { fastForward } from '@synthetixio/core-utils/utils/hardhat/rpc';
+import { wei } from '@synthetixio/wei';
 import forEach from 'mocha-each';
 import { bootstrap } from '../../bootstrap';
-import { genAddress, genBootstrap, genBytes32 } from '../../generators';
+import {
+  genAddress,
+  genBootstrap,
+  genBytes32,
+  genOneOf,
+  genOrder,
+  genOrderFromSizeDelta,
+  genTrader,
+} from '../../generators';
+import { commitAndSettle, depositMargin, setMarketConfigurationById } from '../../helpers';
+import { BigNumber } from 'ethers';
 
 describe('PerpMarketFactoryModule', () => {
   const bs = bootstrap(genBootstrap());
-  const { traders, owner, systems, restore } = bs;
+  const { traders, owner, markets, collaterals, systems, provider, restore } = bs;
 
   beforeEach(restore);
 
@@ -76,13 +89,129 @@ describe('PerpMarketFactoryModule', () => {
     });
   });
 
-  describe('getMarketDigest', () => {
+  describe.only('getMarketDigest', () => {
     describe('{currentFundingRate,fundingVelocity}', () => {
-      it('should compute current funding rate relative to time (concrete)');
+      it('should compute current funding rate relative to time (concrete)', async () => {
+        // This test is pulled directly from a conrete example developed for PerpsV2.
+        //
+        // @see: https://github.com/davidvuong/perpsv2-funding/blob/master/main.ipynb
+        // @see: https://github.com/Synthetixio/synthetix/blob/develop/test/contracts/PerpsV2Market.js#L3631
+        const { PerpMarketProxy } = systems();
 
-      it('should demonstrate a balance market not having zero funding');
+        // Use static market and traders for concrete example.
+        const market = markets()[0]; // OP
+        const collateral = collaterals()[0];
+        const trader1 = traders()[0];
+        const trader2 = traders()[1];
+        const trader3 = traders()[2];
 
-      it('should have zero funding when market is new and empty');
+        // Configure funding and velocity specific parameters so we get deterministic results.
+        await setMarketConfigurationById(bs, market.marketId(), {
+          skewScale: BigNumber.from(10_000_000),
+          maxFundingVelocity: wei(0.25).toBN(),
+          maxMarketSize: BigNumber.from(500_000_000),
+        });
+
+        // Set the market price as funding is denominated in USD.
+        const marketOraclePrice = wei(100).toBN();
+        await market.aggregator().mockSetCurrentPrice(marketOraclePrice);
+
+        // A static list of traders and amount of time to pass by trader and its expected funding.
+        const trades = [
+          // skew = long, r = (t 1000, s 100)
+          {
+            sizeDelta: wei(100).toBN(),
+            account: trader1,
+            fastForwardBySec: 1000,
+            expectedFundingRate: BigNumber.from(0),
+            expectedFundingVelocity: wei(0.025).toBN(),
+          },
+          // skew = even more long, r = (t 30000, s 300)
+          {
+            sizeDelta: wei(200).toBN(),
+            account: trader2,
+            fastForwardBySec: 29_000,
+            expectedFundingRate: wei(0.0083912).toBN(),
+            expectedFundingVelocity: wei(0.075).toBN(),
+          },
+          // skew = balanced but funding rate sticks, r (t 50000, s 0)
+          {
+            sizeDelta: wei(-300).toBN(),
+            account: trader3,
+            fastForwardBySec: 20_000,
+            expectedFundingRate: wei(0.02575231),
+            expectedFundingVelocity: BigNumber.from(0),
+          },
+          // See below for one final fundingRate observation without a trade (no change in rate).
+        ];
+
+        const marginUsdDepositAmount = 1_500_000; // 1.5M margin.
+
+        for (const trade of trades) {
+          const { sizeDelta, account, fastForwardBySec, expectedFundingRate, expectedFundingVelocity } = trade;
+
+          await depositMargin(
+            bs,
+            genTrader(bs, {
+              desiredTrader: account,
+              desiredCollateral: collateral,
+              desiredMarket: market,
+              desiredMarginUsdDepositAmount: marginUsdDepositAmount,
+            })
+          );
+
+          await fastForward(fastForwardBySec, provider());
+
+          const order = await genOrderFromSizeDelta(bs, market, sizeDelta, { desiredKeeperFeeBufferUsd: 0 });
+          console.log(order);
+
+          await commitAndSettle(bs, market.marketId(), account, order);
+
+          const { fundingVelocity, currentFundingRate } = await PerpMarketProxy.getMarketDigest(market.marketId());
+          // console.log(currentFundingRate);
+          // console.log(fundingVelocity);
+
+          // TODO: currentFundingRate not matching but velocity works.
+          assertBn.equal(fundingVelocity, expectedFundingVelocity);
+
+          // const fundingRate = await perpsV2Market.currentFundingRate();
+          // assert.bnClose(fundingRate, expectedRate, toUnit('0.001'));
+
+          // const fundingSequenceLength = await perpsV2Market.fundingSequenceLength();
+          // const funding = await perpsV2Market.fundingSequence(fundingSequenceLength - 1);
+          // assert.bnClose(funding, expectedFunding, toUnit('0.001'));
+        }
+
+        // No change in skew, funding rate/velocity should remain the same.
+        await fastForward(60 * 60 * 24, provider()); // 1 day
+        const { fundingVelocity, currentFundingRate } = await PerpMarketProxy.getMarketDigest(market.marketId());
+        assertBn.equal(fundingVelocity, BigNumber.from(0));
+
+        // assert.bnClose(fundingRate, trades[trades.length - 1].expectedRate, toUnit('0.001'));
+      });
+
+      it('should demonstrate a balance market can have a non-zero funding');
+
+      it('should have zero funding when market is new and empty', async () => {
+        const { PerpMarketProxy } = systems();
+
+        // Use static market and traders for concrete example.
+        const market = genOneOf(markets());
+
+        // Expect zero values.
+        const d1 = await PerpMarketProxy.getMarketDigest(market.marketId());
+        assertBn.isZero(d1.size);
+        assertBn.isZero(d1.currentFundingRate);
+        assertBn.isZero(d1.fundingVelocity);
+
+        await fastForward(60 * 60 * 24, provider());
+
+        // Should still be zero values with no market changes.
+        const d2 = await PerpMarketProxy.getMarketDigest(market.marketId());
+        assertBn.isZero(d2.size);
+        assertBn.isZero(d2.currentFundingRate);
+        assertBn.isZero(d2.fundingVelocity);
+      });
 
       it('should continue to increase funding in same direction so long as market is skewed');
 
@@ -92,7 +221,10 @@ describe('PerpMarketFactoryModule', () => {
 
       it('should cap velocity by maxFundingVelocity');
 
-      // forEach([1, -1]).it('should result in max funding velocity when skew is 100% ({0})', async (side: number) => {});
+      forEach(['long', 'short']).it(
+        'should result in max funding velocity when skew is %s 100%%',
+        async (side: string) => {}
+      );
     });
   });
 });


### PR DESCRIPTION
```
  PerpMarketFactoryModule
    getMarketDigest
      {currentFundingRate,fundingVelocity}
        ✔ should compute current funding rate relative to time (concrete) (395ms)
        ✔ should demonstrate a balance market can have a non-zero funding (256ms)
        ✔ should have zero funding when market is new and empty
        ✔ should change funding direction when skew flips (221ms)
        ✔ should result in max funding velocity when long skewed (152ms)
        ✔ should result in max funding velocity when short skewed (137ms)
        ✔ should continue to increase (long) funding in same direction insofar as market is skewed (123ms)
        ✔ should continue to increase (short) funding in same direction insofar as market is skewed (122ms)


  8 passing (12s)
```

Adds a few more tests for funding and velocity. I've added settlement keeper fee tests too but skipped until I implement another way to test the correct USD value is used. A bug in `hardhat_setNextBlockBaseFeePerGas` means `block.basefee` is always `0`.