### PR TITLE
Withdraw all losing pos

### DIFF
--- a/contracts/interfaces/IOrderModule.sol
+++ b/contracts/interfaces/IOrderModule.sol
@@ -22,20 +22,12 @@ interface IOrderModule is IBasePerpMarket {
     event OrderSettled(
         uint128 indexed accountId,
         uint128 indexed marketId,
+        int128 sizeDelta,
         uint256 orderFee,
         uint256 keeperFee,
         int256 accruedFunding,
         int256 pnl,
         uint256 fillPrice
-    );
-
-    // @dev Emitted when a stale order was canceled.
-    event OrderCanceled(
-        uint128 indexed accountId,
-        uint128 indexed marketId,
-        int256 sizeDelta,
-        uint256 orderFee,
-        uint256 keeperFee
     );
 
     // --- Mutative --- //

--- a/contracts/interfaces/IOrderModule.sol
+++ b/contracts/interfaces/IOrderModule.sol
@@ -38,17 +38,6 @@ interface IOrderModule is IBasePerpMarket {
         uint256 keeperFee
     );
 
-    // --- Runtime structs --- //
-    struct Runtime_settleOrder {
-        uint256 pythPrice;
-        uint256 publishTime;
-        int256 accruedFunding;
-        int256 pnl;
-        uint256 fillPrice;
-        Position.ValidatedTrade trade;
-        Position.TradeParams params;
-    }
-
     // --- Mutative --- //
 
     /**

--- a/contracts/interfaces/IOrderModule.sol
+++ b/contracts/interfaces/IOrderModule.sol
@@ -18,16 +18,6 @@ interface IOrderModule is IBasePerpMarket {
         uint256 estimatedKeeperFee
     );
 
-    // only used due to stack too deep during settlement
-    struct OrderSettleRuntime {
-        uint256 pythPrice;
-        uint256 publishTime;
-        int256 accruedFunding;
-        int256 pnl;
-        uint256 fillPrice;
-        Position.ValidatedTrade trade;
-        Position.TradeParams params;
-    }
     // @dev Emitted when a pending order was successfully settled/executed.
     event OrderSettled(
         uint128 indexed accountId,
@@ -47,6 +37,17 @@ interface IOrderModule is IBasePerpMarket {
         uint256 orderFee,
         uint256 keeperFee
     );
+
+    // --- Runtime structs --- //
+    struct Runtime_settleOrder {
+        uint256 pythPrice;
+        uint256 publishTime;
+        int256 accruedFunding;
+        int256 pnl;
+        uint256 fillPrice;
+        Position.ValidatedTrade trade;
+        Position.TradeParams params;
+    }
 
     // --- Mutative --- //
 

--- a/contracts/interfaces/IOrderModule.sol
+++ b/contracts/interfaces/IOrderModule.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.19;
 
 import "./IBasePerpMarket.sol";
+import {Position} from "../storage/Position.sol";
 import {Order} from "../storage/Order.sol";
 
 interface IOrderModule is IBasePerpMarket {
@@ -17,11 +18,32 @@ interface IOrderModule is IBasePerpMarket {
         uint256 estimatedKeeperFee
     );
 
+    // only used due to stack too deep during settlement
+    struct OrderSettleRuntime {
+        uint256 pythPrice;
+        uint256 publishTime;
+        int256 accruedFunding;
+        int256 pnl;
+        uint256 fillPrice;
+        Position.ValidatedTrade trade;
+        Position.TradeParams params;
+    }
     // @dev Emitted when a pending order was successfully settled/executed.
     event OrderSettled(
         uint128 indexed accountId,
         uint128 indexed marketId,
-        int128 sizeDelta,
+        uint256 orderFee,
+        uint256 keeperFee,
+        int256 accruedFunding,
+        int256 pnl,
+        uint256 fillPrice
+    );
+
+    // @dev Emitted when a stale order was canceled.
+    event OrderCanceled(
+        uint128 indexed accountId,
+        uint128 indexed marketId,
+        int256 sizeDelta,
         uint256 orderFee,
         uint256 keeperFee
     );

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -162,6 +162,16 @@ contract OrderModule is IOrderModule {
         delete market.orders[accountId];
     }
 
+    struct Runtime_settleOrder {
+        uint256 pythPrice;
+        uint256 publishTime;
+        int256 accruedFunding;
+        int256 pnl;
+        uint256 fillPrice;
+        Position.ValidatedTrade trade;
+        Position.TradeParams params;
+    }
+
     /**
      * @inheritdoc IOrderModule
      */
@@ -169,7 +179,7 @@ contract OrderModule is IOrderModule {
         Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         Order.Data storage order = market.orders[accountId];
-        OrderSettleRuntime memory runtime;
+        Runtime_settleOrder memory runtime;
 
         // No order available to settle.
         if (order.sizeDelta == 0) {

--- a/contracts/storage/Margin.sol
+++ b/contracts/storage/Margin.sol
@@ -231,12 +231,11 @@ library Margin {
         if (position.size == 0) {
             return collateralValueUsd;
         }
-        int256 pnl = position.getPnl(price);
         return
             MathUtil
                 .max(
                     collateralValueUsd.toInt() +
-                        pnl +
+                        position.getPnl(price) +
                         position.getAccruedFunding(market, price) -
                         position.accruedFeesUsd.toInt(),
                     0

--- a/contracts/storage/PerpMarket.sol
+++ b/contracts/storage/PerpMarket.sol
@@ -52,7 +52,7 @@ library PerpMarket {
         uint256 lastFundingTime;
         // This is needed to perform a fast constant time op for overall market debt.
         //
-        // debtCorrection = positions.sum(p.margin - p.size * (p.entryPrice + p.entryFunding))
+        // debtCorrection = positions.sum(p.collateralUsd - p.size * (p.entryPrice + p.entryFunding))
         // marketDebt     = market.skew * (price + nextFundingEntry) + debtCorrection
         int128 debtCorrection;
         // {accountId: Order}.
@@ -114,6 +114,7 @@ library PerpMarket {
         uint256 entryPrice,
         int256 entryFundingAccrued
     ) internal pure returns (int256) {
+        // TODO figure out if we should be dedecuting fees here.
         return marginUsd.toInt() - (size.mulDecimal(entryPrice.toInt() + entryFundingAccrued));
     }
 
@@ -124,17 +125,17 @@ library PerpMarket {
         PerpMarket.Data storage self,
         Position.Data storage oldPosition,
         Position.Data memory newPosition,
-        uint256 marginUsd,
+        uint256 collateralUsd,
         uint256 newMarginUsd
     ) internal {
         int256 oldCorrection = getPositionDebtCorrection(
-            marginUsd,
+            collateralUsd,
             oldPosition.size,
             oldPosition.entryPrice,
             oldPosition.entryFundingAccrued
         );
         int256 newCorrection = getPositionDebtCorrection(
-            newMarginUsd,
+            newMarginUsd, // TODO  this should probably be collatrealUsd, fix when adding test for debtCorrection
             newPosition.size,
             newPosition.entryPrice,
             newPosition.entryFundingAccrued

--- a/contracts/storage/Position.sol
+++ b/contracts/storage/Position.sol
@@ -150,7 +150,7 @@ library Position {
 
         Position.Data storage currentPosition = market.positions[accountId];
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(market.id);
-        uint256 marginUsd = Margin.getMarginUsd(accountId, market, params.oraclePrice);
+        uint256 marginUsd = Margin.getMarginUsd(accountId, market, params.fillPrice);
 
         // --- Existing position validation --- //
 

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -165,7 +165,7 @@ export const genOrder = async (
     desiredLeverage?: number;
     desiredSide?: 1 | -1;
     desiredKeeperFeeBufferUsd?: number;
-    desiredSize?: Wei; // Note if desiredSize is specified, desiredSide and leverage will be ignored.
+    desiredSize?: BigNumber; // Note if desiredSize is specified, desiredSide and leverage will be ignored.
   }
 ) => {
   const { PerpMarketProxy } = systems();
@@ -185,7 +185,7 @@ export const genOrder = async (
 
   // `desiredSide` is specified, just use that.
   if (options?.desiredSize) {
-    sizeDelta = options.desiredSize.toBN();
+    sizeDelta = options.desiredSize;
   } else if (options?.desiredSide) {
     sizeDelta = sizeDelta.mul(options.desiredSide);
   } else {

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { BigNumber, ethers } from 'ethers';
 import { shuffle, isNil, random } from 'lodash';
-import { wei } from '@synthetixio/wei';
+import Wei, { wei } from '@synthetixio/wei';
 import { MARKETS } from './data/markets.fixture';
 import { Bs, Market, Trader, Collateral } from './typed';
 
@@ -165,6 +165,7 @@ export const genOrder = async (
     desiredLeverage?: number;
     desiredSide?: 1 | -1;
     desiredKeeperFeeBufferUsd?: number;
+    desiredSize?: Wei; // Not is desiredSize is specified, desiredSide and leverage will be ignored.
   }
 ) => {
   const { PerpMarketProxy } = systems();
@@ -173,16 +174,19 @@ export const genOrder = async (
     ? wei(options?.desiredKeeperFeeBufferUsd).toBN()
     : genKeeperFeeBufferUsd();
 
-  // Use a reasonble amount of leverage
+  // Use a reasonable amount of leverage.
   const leverage = options?.desiredLeverage ?? genOneOf([0.5, 1, 2, 3, 4, 5]);
 
   const { answer: collateralPrice } = await collateral.aggregator().latestRoundData();
   const marginUsd = wei(collateralDepositAmount).mul(collateralPrice).sub(keeperFeeBufferUsd);
 
-  // Randomly use long/short unless `desiredSide` is specified.
   const oraclePrice = await PerpMarketProxy.getOraclePrice(market.marketId());
   let sizeDelta = marginUsd.div(oraclePrice).mul(wei(leverage)).toBN();
-  if (options?.desiredSide) {
+
+  // `desiredSide` is specified, just use that.
+  if (options?.desiredSize) {
+    sizeDelta = options.desiredSize.toBN();
+  } else if (options?.desiredSide) {
     sizeDelta = sizeDelta.mul(options.desiredSide);
   } else {
     sizeDelta = sizeDelta.mul(genSide());

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -165,7 +165,7 @@ export const genOrder = async (
     desiredLeverage?: number;
     desiredSide?: 1 | -1;
     desiredKeeperFeeBufferUsd?: number;
-    desiredSize?: Wei; // Not is desiredSize is specified, desiredSide and leverage will be ignored.
+    desiredSize?: Wei; // Note if desiredSize is specified, desiredSide and leverage will be ignored.
   }
 ) => {
   const { PerpMarketProxy } = systems();

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -13,6 +13,14 @@ export const raise = (err: string): never => {
 
 export const bn = (n: number) => wei(n).toBN();
 
+export function* toRoundRobinGenerators<A>(l: A[]): Generator<A> {
+  let idx = 0;
+  while (true) {
+    yield l[idx];
+    idx = (idx + 1) % l.length;
+  }
+}
+
 // --- Primitive generators --- //
 
 export const genTimes = <A>(n: number, f: (n?: number) => A) => [...Array(n).keys()].map(f);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -216,6 +216,3 @@ export const txWait = async (tx: ethers.ContractTransaction, provider: ethers.pr
   await provider.send('evm_mine', []);
   return await tx.wait();
 };
-
-export const createTxWait = (provider: ethers.providers.JsonRpcProvider) => (tx: ethers.ContractTransaction) =>
-  txWait(tx, provider);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -201,13 +201,7 @@ export const findEventSafe = ({
   eventName: string;
   contract: Contract;
 }) => {
-  if (!receipt.logs) {
-    throw new Error(
-      `no logs found when searching for event ${eventName}. Did you actually pass a transaction receipt into findEvent?`
-    );
-  }
-
-  const foundEvent = receipt.logs
+  return receipt.logs
     .map((log) => {
       try {
         return contract.interface.parseLog(log);
@@ -216,8 +210,6 @@ export const findEventSafe = ({
       }
     })
     .find((parsedEvent) => parsedEvent?.name === eventName);
-  if (!foundEvent) return;
-  return foundEvent;
 };
 
 export const txWait = async (tx: ethers.ContractTransaction, provider: ethers.providers.JsonRpcProvider) => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, ContractReceipt, utils } from 'ethers';
+import { BigNumber, Contract, ContractReceipt, ethers, utils } from 'ethers';
 import { LogLevel } from '@ethersproject/logger';
 import { PerpMarketConfiguration } from './generated/typechain/MarketConfigurationModule';
 import type { bootstrap } from './bootstrap';
@@ -206,6 +206,7 @@ export const findEventSafe = ({
       `no logs found when searching for event ${eventName}. Did you actually pass a transaction receipt into findEvent?`
     );
   }
+
   const foundEvent = receipt.logs
     .map((log) => {
       try {
@@ -218,3 +219,11 @@ export const findEventSafe = ({
   if (!foundEvent) return;
   return foundEvent;
 };
+
+export const txWait = async (tx: ethers.ContractTransaction, provider: ethers.providers.JsonRpcProvider) => {
+  await provider.send('evm_mine', []);
+  return await tx.wait();
+};
+
+export const createTxWait = (provider: ethers.providers.JsonRpcProvider) => (tx: ethers.ContractTransaction) =>
+  txWait(tx, provider);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, utils } from 'ethers';
+import { BigNumber, Contract, ContractReceipt, utils } from 'ethers';
 import { LogLevel } from '@ethersproject/logger';
 import { PerpMarketConfiguration } from './generated/typechain/MarketConfigurationModule';
 import type { bootstrap } from './bootstrap';
@@ -6,6 +6,7 @@ import { type genTrader, type genOrder, genNumber } from './generators';
 import { wei } from '@synthetixio/wei';
 import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import { isNil, uniq } from 'lodash';
+import { LogDescription } from 'ethers/lib/utils';
 
 // --- Constants --- //
 
@@ -189,4 +190,31 @@ export const extendContractAbi = (contract: Contract, abi: string[]) => {
   );
   utils.Logger.setLogLevel(LogLevel.WARNING); // enable default logging again
   return newContract;
+};
+
+export const findEventSafe = ({
+  receipt,
+  eventName,
+  contract,
+}: {
+  receipt: ContractReceipt;
+  eventName: string;
+  contract: Contract;
+}) => {
+  if (!receipt.logs) {
+    throw new Error(
+      `no logs found when searching for event ${eventName}. Did you actually pass a transaction receipt into findEvent?`
+    );
+  }
+  const foundEvent = receipt.logs
+    .map((log) => {
+      try {
+        return contract.interface.parseLog(log);
+      } catch (error) {
+        return undefined;
+      }
+    })
+    .find((parsedEvent) => parsedEvent?.name === eventName);
+  if (!foundEvent) return;
+  return foundEvent;
 };

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -861,6 +861,7 @@ describe('MarginModule', async () => {
             desiredTrader: tradersGenerator.next().value,
           })
         );
+        // TODO: investigate this
         // For some collateral + trader combinations the trader has a balance bigger than collateralDepositAmount, so record the full balance here.
         const startingCollateralBalance = wei(await collateral.contract.balanceOf(traderAddress)).add(
           collateralDepositAmount

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -887,7 +887,8 @@ describe('MarginModule', async () => {
 
         const closeOrder = await genOrder(bs, market, collateral, collateralDepositAmount, {
           desiredKeeperFeeBufferUsd: 0,
-          desiredSize: wei(order.sizeDelta).mul(-1),
+          desiredSize: wei(order.sizeDelta).mul(-1).toBN(),
+          desiredLeverage: 2,
         });
 
         const tx = await commitAndSettle(bs, marketId, trader, closeOrder);

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -270,7 +270,7 @@ describe('OrderModule', () => {
 
       await assertEvent(
         tx,
-        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${keeperFee}, 0, 0, ${order.fillPrice})`,
+        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${keeperFee}, ${accruedFunding}, ${pnl}, ${order.fillPrice})`,
         PerpMarketProxy
       );
 

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -10,7 +10,9 @@ import { bootstrap } from '../../bootstrap';
 import { genBootstrap, genNumber, genOrder, genTrader } from '../../generators';
 import {
   commitAndSettle,
+  txWait,
   depositMargin,
+  findEventSafe,
   getFastForwardTimestamp,
   getPythPriceData,
   setMarketConfiguration,
@@ -39,7 +41,7 @@ describe('OrderModule', () => {
         order.limitPrice,
         order.keeperFeeBufferUsd
       );
-      const receipt = await tx.wait();
+      const receipt = await txWait(tx, provider());
       const block = await provider().getBlock(receipt.blockNumber);
 
       const pendingOrder = await PerpMarketProxy.getOrderDigest(trader.accountId, marketId);
@@ -48,11 +50,22 @@ describe('OrderModule', () => {
       assertBn.equal(pendingOrder.keeperFeeBufferUsd, order.keeperFeeBufferUsd);
       assertBn.equal(pendingOrder.commitmentTime, block.timestamp);
 
-      const { orderFee, keeperFee } = await PerpMarketProxy.getOrderFees(marketId, order.sizeDelta, order.keeperFee);
+      const { orderFee, keeperFee: _keeperFees } = await PerpMarketProxy.getOrderFees(
+        marketId,
+        order.sizeDelta,
+        order.keeperFee
+      );
+      // It's a little weird to get the event that we're asserting, we're doing this to get the correct base fee, anvil have some issue with consistent base fee, which keeperFee is based on.
+      const { args: orderCommittedArgs } =
+        findEventSafe({
+          receipt,
+          eventName: 'OrderSubmitted',
+          contract: PerpMarketProxy,
+        }) || {};
 
       await assertEvent(
         tx,
-        `OrderSubmitted(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${block.timestamp}, ${orderFee}, ${keeperFee})`,
+        `OrderSubmitted(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${block.timestamp}, ${orderFee}, ${orderCommittedArgs?.estimatedKeeperFee})`,
         PerpMarketProxy
       );
     });
@@ -264,13 +277,20 @@ describe('OrderModule', () => {
       const tx = await PerpMarketProxy.connect(keeper()).settleOrder(trader.accountId, marketId, [updateData], {
         value: updateFee,
       });
+      const receipt = await txWait(tx, provider());
+      const { args: orderSettledArgs } =
+        findEventSafe({
+          receipt,
+          eventName: 'OrderSettled',
+          contract: PerpMarketProxy,
+        }) || {};
       // This is an open order, so no funding or pnl
       const accruedFunding = 0;
       const pnl = 0;
 
       await assertEvent(
         tx,
-        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${keeperFee}, ${accruedFunding}, ${pnl}, ${order.fillPrice})`,
+        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${orderSettledArgs.keeperFee}, ${accruedFunding}, ${pnl}, ${order.fillPrice})`,
         PerpMarketProxy
       );
 

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -264,10 +264,13 @@ describe('OrderModule', () => {
       const tx = await PerpMarketProxy.connect(keeper()).settleOrder(trader.accountId, marketId, [updateData], {
         value: updateFee,
       });
+      // This is an open order, so no funding or pnl
+      const accruedFunding = 0;
+      const pnl = 0;
 
       await assertEvent(
         tx,
-        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${keeperFee})`,
+        `OrderSettled(${trader.accountId}, ${marketId}, ${order.sizeDelta}, ${orderFee}, ${keeperFee}, 0, 0, ${order.fillPrice})`,
         PerpMarketProxy
       );
 
@@ -304,7 +307,7 @@ describe('OrderModule', () => {
       // There should be no order.
       assertBn.isZero((await PerpMarketProxy.getOrderDigest(trader.accountId, marketId)).sizeDelta);
 
-      // There should be no order and no position.
+      // There should no position.
       assertBn.isZero((await PerpMarketProxy.getPositionDigest(trader.accountId, marketId)).size);
     });
 


### PR DESCRIPTION
Functionality change:
- Make sure we use fillPrice when, validating trade since this will be used for pnl accounting
-  Make sure `updateMarketPostSettlement` gets passed collateralUsd rather than marginUsd. marginUsd would have pnl incorated already..
- More events for `OrderSettled`, also hade to use runtime var to avoid stack too deep.

New test helper:
- `findEventSafe`, `findEvent` from core throws if it cant decode ALL events. 
