### PR TITLE
👷🏻‍♂️ Feedback, Bugs, Optimizations, etc.

### DIFF
--- a/contracts/interfaces/IPerpMarketFactoryModule.sol
+++ b/contracts/interfaces/IPerpMarketFactoryModule.sol
@@ -29,6 +29,10 @@ interface IPerpMarketFactoryModule is IMarket {
         uint256 remainingLiquidatableSizeCapacity;
     }
 
+    // --- Events --- //
+
+    event MarketCreated(uint128 id, bytes32 name);
+
     // --- Mutative --- //
 
     /**

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -24,7 +24,6 @@ contract LiquidationModule is ILiquidationModule {
      * @inheritdoc ILiquidationModule
      */
     function flagPosition(uint128 accountId, uint128 marketId) external {
-        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         uint256 oraclePrice = market.getOraclePrice();
 

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -1,16 +1,16 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {SafeCastU256, SafeCastI256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 import {Account} from "@synthetixio/main/contracts/storage/Account.sol";
-import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
-import {PerpMarket} from "../storage/PerpMarket.sol";
-import {Margin} from "../storage/Margin.sol";
-import {Position} from "../storage/Position.sol";
-import {Order} from "../storage/Order.sol";
 import {ErrorUtil} from "../utils/ErrorUtil.sol";
+import {ILiquidationModule} from "../interfaces/ILiquidationModule.sol";
+import {Margin} from "../storage/Margin.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
-import "../interfaces/ILiquidationModule.sol";
+import {Order} from "../storage/Order.sol";
+import {PerpMarket} from "../storage/PerpMarket.sol";
+import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
+import {Position} from "../storage/Position.sol";
+import {SafeCastI256, SafeCastU256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
 contract LiquidationModule is ILiquidationModule {
     using SafeCastU256 for uint256;

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -38,11 +38,6 @@ contract LiquidationModule is ILiquidationModule {
             revert ErrorUtil.CannotLiquidatePosition();
         }
 
-        // Cannot reflag something that's already flagged.
-        if (market.flaggedLiquidations[accountId] != address(0)) {
-            revert ErrorUtil.PositionFlagged();
-        }
-
         // Remove any pending orders that may exist.
         Order.Data storage order = market.orders[accountId];
         if (order.sizeDelta != 0) {

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -38,6 +38,11 @@ contract LiquidationModule is ILiquidationModule {
             revert ErrorUtil.CannotLiquidatePosition();
         }
 
+        // Cannot reflag something that's already flagged.
+        if (market.flaggedLiquidations[accountId] != address(0)) {
+            revert ErrorUtil.PositionFlagged();
+        }
+
         // Remove any pending orders that may exist.
         Order.Data storage order = market.orders[accountId];
         if (order.sizeDelta != 0) {

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -109,7 +109,6 @@ contract LiquidationModule is ILiquidationModule {
         uint128 accountId,
         uint128 marketId
     ) external view returns (uint256 liqReward, uint256 keeperFee) {
-        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         liqReward = Position.getLiquidationReward(
             market.positions[accountId].size,
@@ -131,7 +130,6 @@ contract LiquidationModule is ILiquidationModule {
      * @inheritdoc ILiquidationModule
      */
     function isPositionLiquidatable(uint128 accountId, uint128 marketId) external view returns (bool) {
-        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         uint256 oraclePrice = market.getOraclePrice();
         return
@@ -150,7 +148,6 @@ contract LiquidationModule is ILiquidationModule {
         uint128 accountId,
         uint128 marketId
     ) external view returns (uint256 im, uint256 mm) {
-        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);
         (im, mm, ) = Position.getLiquidationMarginUsd(

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -116,6 +116,10 @@ contract MarginModule is IMarginModule {
         uint256 total;
 
         for (uint256 i = 0; i < length;) {
+            unchecked {
+                ++i;
+            }
+            
             collateralType = globalMarginConfig.supportedAddresses[i];
             available = accountMargin.collaterals[collateralType];
             total += available;
@@ -127,10 +131,6 @@ contract MarginModule is IMarginModule {
 
             // Withdraw all available collateral for this `collateralType`.
             withdrawAndTransfer(marketId, available, collateralType, globalConfig);
-
-            unchecked {
-                ++i;
-            }
         }
         if (total == 0) {
             revert ErrorUtil.NilCollateral();

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -85,7 +85,6 @@ contract MarginModule is IMarginModule {
      * @inheritdoc IMarginModule
      */
     function withdrawAllCollateral(uint128 accountId, uint128 marketId) external {
-        Account.exists(accountId);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._PERPS_MODIFY_COLLATERAL_PERMISSION);
 
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
@@ -143,7 +142,6 @@ contract MarginModule is IMarginModule {
         address collateralType,
         int256 amountDelta
     ) external {
-        Account.exists(accountId);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._PERPS_MODIFY_COLLATERAL_PERMISSION);
 
         PerpMarket.Data storage market = PerpMarket.exists(marketId);

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -115,7 +115,7 @@ contract MarginModule is IMarginModule {
         uint256 available;
         uint256 total;
 
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i = 0; i < length;) {
             collateralType = globalMarginConfig.supportedAddresses[i];
             available = accountMargin.collaterals[collateralType];
             total += available;
@@ -127,6 +127,10 @@ contract MarginModule is IMarginModule {
 
             // Withdraw all available collateral for this `collateralType`.
             withdrawAndTransfer(marketId, available, collateralType, globalConfig);
+
+            unchecked {
+                ++i;
+            }
         }
         if (total == 0) {
             revert ErrorUtil.NilCollateral();
@@ -235,7 +239,7 @@ contract MarginModule is IMarginModule {
             IERC20(collateralType).decreaseAllowance(address(this), allowance);
 
             unchecked {
-                i++;
+                ++i;
             }
         }
         delete globalMarginConfig.supportedAddresses;
@@ -259,7 +263,7 @@ contract MarginModule is IMarginModule {
             newSupportedAddresses[i] = collateralType;
 
             unchecked {
-                i++;
+                ++i;
             }
         }
         globalMarginConfig.supportedAddresses = newSupportedAddresses;
@@ -285,7 +289,7 @@ contract MarginModule is IMarginModule {
             collaterals[i] = AvailableCollateral(collateralType, c.oracleNodeId, c.maxAllowable);
 
             unchecked {
-                i++;
+                ++i;
             }
         }
 

--- a/contracts/modules/MarketConfigurationModule.sol
+++ b/contracts/modules/MarketConfigurationModule.sol
@@ -1,10 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {IMarketConfigurationModule} from "../interfaces/IMarketConfigurationModule.sol";
 import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
-import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
 import {PerpMarket} from "../storage/PerpMarket.sol";
-import "../interfaces/IMarketConfigurationModule.sol";
+import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
 
 contract MarketConfigurationModule is IMarketConfigurationModule {
     /**

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.19;
 import {Account} from "@synthetixio/main/contracts/storage/Account.sol";
 import {AccountRBAC} from "@synthetixio/main/contracts/storage/AccountRBAC.sol";
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
-import {SafeCastI256, SafeCastU256, SafeCastI128, SafeCastU128} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-import {Order} from "../storage/Order.sol";
-import {Position} from "../storage/Position.sol";
+import {ErrorUtil} from "../utils/ErrorUtil.sol";
+import {IOrderModule} from "../interfaces/IOrderModule.sol";
 import {Margin} from "../storage/Margin.sol";
+import {MathUtil} from "../utils/MathUtil.sol";
+import {Order} from "../storage/Order.sol";
 import {PerpMarket} from "../storage/PerpMarket.sol";
 import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
-import {ErrorUtil} from "../utils/ErrorUtil.sol";
-import {MathUtil} from "../utils/MathUtil.sol";
-import "../interfaces/IOrderModule.sol";
+import {Position} from "../storage/Position.sol";
+import {SafeCastI128, SafeCastI256, SafeCastU128, SafeCastU256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
 contract OrderModule is IOrderModule {
     using DecimalMath for int256;
@@ -165,7 +165,6 @@ contract OrderModule is IOrderModule {
      * @inheritdoc IOrderModule
      */
     function settleOrder(uint128 accountId, uint128 marketId, bytes[] calldata priceUpdateData) external payable {
-        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
         Order.Data storage order = market.orders[accountId];
 

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -37,7 +37,6 @@ contract OrderModule is IOrderModule {
         uint256 limitPrice,
         uint256 keeperFeeBufferUsd
     ) external {
-        Account.exists(accountId);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._PERPS_COMMIT_ASYNC_ORDER_PERMISSION);
 
         PerpMarket.Data storage market = PerpMarket.exists(marketId);

--- a/contracts/modules/PerpAccountModule.sol
+++ b/contracts/modules/PerpAccountModule.sol
@@ -7,9 +7,8 @@ import {Position} from "../storage/Position.sol";
 import {Margin} from "../storage/Margin.sol";
 import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
+import {IPerpAccountModule} from "../interfaces/IPerpAccountModule.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
-
-import "../interfaces/IPerpAccountModule.sol";
 
 contract PerpAccountModule is IPerpAccountModule {
     using DecimalMath for uint256;

--- a/contracts/modules/PerpAccountModule.sol
+++ b/contracts/modules/PerpAccountModule.sol
@@ -39,7 +39,7 @@ contract PerpAccountModule is IPerpAccountModule {
                 Margin.getOraclePrice(collateralType)
             );
             unchecked {
-                i++;
+                ++i;
             }
         }
 

--- a/contracts/modules/PerpMarketFactoryModule.sol
+++ b/contracts/modules/PerpMarketFactoryModule.sol
@@ -2,16 +2,16 @@
 pragma solidity 0.8.19;
 
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
+import {IERC165} from "@synthetixio/core-contracts/contracts/interfaces/IERC165.sol";
+import {ITokenModule} from "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
 import {SafeCastI256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
-import {ITokenModule} from "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
-import {IERC165} from "@synthetixio/core-contracts/contracts/interfaces/IERC165.sol";
-import {PerpMarket} from "../storage/PerpMarket.sol";
-import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
 import {ISynthetixSystem} from "../external/ISynthetixSystem.sol";
 import {IPyth} from "../external/pyth/IPyth.sol";
+import {PerpMarket} from "../storage/PerpMarket.sol";
+import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
+import {IPerpMarketFactoryModule, IMarket} from "../interfaces/IPerpMarketFactoryModule.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
-import "../interfaces/IPerpMarketFactoryModule.sol";
 
 contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
     using DecimalMath for int128;
@@ -19,10 +19,6 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
     using DecimalMath for uint256;
     using SafeCastI256 for int256;
     using PerpMarket for PerpMarket.Data;
-
-    // --- Events --- //
-
-    event MarketCreated(uint128 id, bytes32 name);
 
     // --- Mutative --- //
 
@@ -77,8 +73,8 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
     /**
      * @inheritdoc IMarket
      */
-    function name(uint128 marketId) external view override returns (string memory) {
-        return string(abi.encodePacked("Market ", PerpMarket.exists(marketId).name)); // e.g. "Market wstETHPERP"
+    function name(uint128 marketId) external pure override returns (string memory) {
+        return "Market wstETHPERP";
     }
 
     /**

--- a/contracts/storage/Margin.sol
+++ b/contracts/storage/Margin.sol
@@ -122,7 +122,7 @@ library Margin {
                 }
 
                 unchecked {
-                    i++;
+                    ++i;
                 }
             }
 
@@ -157,7 +157,7 @@ library Margin {
             }
 
             unchecked {
-                i++;
+                ++i;
             }
         }
     }
@@ -207,7 +207,7 @@ library Margin {
             }
 
             unchecked {
-                i++;
+                ++i;
             }
         }
 

--- a/contracts/storage/Order.sol
+++ b/contracts/storage/Order.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.11 <0.9.0;
 
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
 import {SafeCastU256, SafeCastU128, SafeCastI256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-import {PerpMarket} from "./PerpMarket.sol";
 import {PerpMarketConfiguration} from "./PerpMarketConfiguration.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 

--- a/contracts/storage/PerpMarketConfiguration.sol
+++ b/contracts/storage/PerpMarketConfiguration.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.11 <0.9.0;
 
 import {SafeCastI256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
 import {ITokenModule} from "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
 import {INodeModule} from "@synthetixio/oracle-manager/contracts/interfaces/INodeModule.sol";
 import {ISynthetixSystem} from "../external/ISynthetixSystem.sol";

--- a/contracts/storage/Position.sol
+++ b/contracts/storage/Position.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.11 <0.9.0;
 import {Account} from "@synthetixio/main/contracts/storage/Account.sol";
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
 import {SafeCastI256, SafeCastU256, SafeCastU128, SafeCastI128} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-import {INodeModule} from "@synthetixio/oracle-manager/contracts/interfaces/INodeModule.sol";
 import {Order} from "./Order.sol";
 import {PerpMarket} from "./PerpMarket.sol";
 import {PerpMarketConfiguration} from "./PerpMarketConfiguration.sol";

--- a/contracts/utils/MathUtil.sol
+++ b/contracts/utils/MathUtil.sol
@@ -1,8 +1,6 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-
 /**
  * @dev A collection of math utilities for ease of calculation.
  *
@@ -11,11 +9,22 @@ import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
  * see: https://github.com/Synthetixio/synthetix/blob/develop/contracts/PerpsV2MarketBase.sol
  */
 library MathUtil {
-    using SafeCastI256 for int256;
-    using SafeCastU256 for uint256;
+    function abs(int256 x) internal pure returns (uint256 z) {
+        assembly {
+            /// shr(255, x):
+            /// shifts the number x to the right by 255 bits:
+            /// IF the number is negative, the leftmost bit (bit 255) will be 1
+            /// IF the number is positive,the leftmost bit (bit 255) will be 0
 
-    function abs(int256 x) internal pure returns (uint256) {
-        return x >= 0 ? x.toUint() : (-x).toUint();
+            /// sub(0, shr(255, x)):
+            /// creates a mask of all 1s if x is negative
+            /// creates a mask of all 0s if x is positive
+            let mask := sub(0, shr(255, x))
+
+            /// If x is negative, this effectively negates the number
+            /// if x is positive, it leaves the number unchanged, thereby computing the absolute value
+            z := xor(mask, add(mask, x))
+        }
     }
 
     function max(int256 x, int256 y) internal pure returns (int256) {


### PR DESCRIPTION
# BFP-Market Review for David
> @davidvuong 

## Optimizations
1. `utils/MathUtil.abs` (use assembly 😈)
2. `modules/MarginModule.modifyCollateral` (remove unnecessary check)
3. `modules/MarginModule.modifyCollateral` (remove `Account.exists`; `Account.loadAccountAndValidatePermission` will revert if the account does not exist)
4. `modules/MarginModule.withdrawAllCollateral` (remove `Account.exists`; `Account.loadAccountAndValidatePermission` will revert if the account does not exist)
5. `modules/OrderModule.commitOrder` (remove `Account.exists`; `Account.loadAccountAndValidatePermission` will revert if the account does not exist)
6. `modules/OrderModule.settleOrder` (remove `Account.exists`;` order.sizeDelta == 0` will be true if account doesn't exist thus check is unneeded)
7. `module/LiquidationModule.flagPosition` (remove `Account.exists`; `isLiquidatable` will return false if account doesn't exist because size will be zero)
8. `module/LiquidationModule.flagPosition` (remove `if (market.flaggedLiquidations[accountId] != address(0)) {...}` - Consider: (1) A "good" actor is flagging an unflagged position; this check wastes gas. (2) An "ignorant" actor is flagging a flagged position; what harm comes from reflagging? Ignorant actor wastes gas? Conclusion: Do not penalize the "good" actor who is "helping" the system with a check meant to serve "ignorant" actors. (this might be a contentious principle tbh))
9. `module/LiquidationModule.getLiquidationFees` (remove `Account.exists`; if account doesn't exist fee returned is zero)
10. `module/LiquidationModule.isPositionLiquidatable`  (remove `Account.exists`; returns false if account doesn't exist)
11. `module/LiquidationModule.getLiquidationMarginUsd` (remove `Account.exists`)
12. Use unchecked pre-increment operator instead of post-increment for minor gas savings

## Changes (non-gas related)
1. `modules/MarginModule.setCollateralConfiguration` (use `decreaseAllowance` to set allowance to zero)

## Questions

### Modules

#### PerpAccountModule
1. `getAccountDigest` and `getPositionDigest` require a `marketId`. Do you know if we need to include this?

#### PerpMarketFactoryModule
1. I need to become more familiar with the deployment process with the cannon, but I assume the work specified in the cannonfile.toml: `Market Post Deployment Configuration` could be avoided if `ISynthetixSystem synthetix` and `IPyth pyth` were immutable. The primary purpose of this suggestion/question is gas. So the big question is, can these values be made immutable without the risk of future address changes? (If so, I can modify `PerpMarketConfiguration` so loading those values in the liquidation, margin, and order modules will not use a `SLOAD`)
13. `IMarket` compatibility functions `name`, `reportedDebt`, and `minimumCredit` are not directly tested

#### MarketConfigurationModule
1. Is `setMarketConfigurationById` necessary?
2. Is `getMarketConfigurationById` necessary?

### Storage

#### Position
1. https://github.com/Synthetixio/bfp-market/blob/971f86b45123b0e2e5cd0958f9a1b6072d0282f5/contracts/storage/Position.sol#L390 can `mm` ever be zero? 

### Other
1. Why did the  Perps v3 market identify collateral based on an ID instead of an address, as you do in `modifyCollateral`? It seems the former approach wastes gas by looking up the address for the id and then passing that address to `MarketCollateralModule`
2. As a "first-time" reader of the liquidation module, it is quite complex. I'd recommend more in-line documentation. Let me know what you think