### PR TITLE
Feature/price divergence

### DIFF
--- a/contracts/utils/ErrorUtil.sol
+++ b/contracts/utils/ErrorUtil.sol
@@ -23,6 +23,9 @@ library ErrorUtil {
     // @notice Thrown when an order cannot settle due to limitPrice tolerance not met.
     error PriceToleranceExceeded(int128 sizeDelta, uint256 price, uint256 limitPrice);
 
+    // @notice Thrown during settlement when off-chain diverges too far from on-chain price.
+    error PriceDivergenceExceeded(uint256 offchainPrice, uint256 onchainPrice);
+
     // @notice Thrown when the operating market does not exist.
     error MarketNotFound(uint128 marketId);
 

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -65,7 +65,7 @@ export const genBootstrap = () => ({
     stakedAmount: bn(500_000),
   },
   global: {
-    priceDivergencePercent: wei(genNumber(0.1, 0.3)).toBN(),
+    priceDivergencePercent: bn(genOneOf([0.01, 0.02, 0.03, 0.035, 0.04, 0.045, 0.05])),
     pythPublishTimeMin: 8,
     pythPublishTimeMax: 12,
     minOrderAge: 12,


### PR DESCRIPTION
- This PR adds back PriceDivergenceExceeded reverts when CL price exceeds Pyth price by some globally configurable `priceDivergencePercent` value.
- Additionally an accompanying test to assert correctness.