### PR TITLE
Feature/susd collateral everywhere

### DIFF
--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -141,27 +141,27 @@ factory.PerpAccountProxy.arg = 2
 
 # --- Mocks --- #
 
-[contract.SnxV3CollateralMock]
+[contract.CollateralMock]
 artifact = "contracts/mocks/CollateralMock.sol:CollateralMock"
 args = []
 salt = "1"
 
-[contract.SynthetixCollateral2Mock]
+[contract.Collateral2Mock]
 artifact = "contracts/mocks/CollateralMock.sol:CollateralMock"
 args = []
 salt = "2"
 
 [invoke.initialize_snxCollateral]
-target = ["SnxV3CollateralMock"]
+target = ["CollateralMock"]
 func = "initialize"
 args = ["SNX V3","SNXV3","18"]
-depends = ["contract.SnxV3CollateralMock"]
+depends = ["contract.CollateralMock"]
 
 [invoke.initialize_xxxCollateral]
-target = ["SynthetixCollateral2Mock"]
+target = ["Collateral2Mock"]
 func = "initialize"
 args = ["XXX X","XXX","18"]
-depends = ["contract.SynthetixCollateral2Mock"]
+depends = ["contract.Collateral2Mock"]
 
 [contract.PythMock]
 artifact = "contracts/mocks/PythMock.sol:PythMock"

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -99,7 +99,7 @@ contract MarginModule is IMarginModule {
         PerpMarketConfiguration.GlobalData storage globalConfig
     ) private {
         if (synthMarketId == SYNTHETIX_USD_MARKET_ID) {
-            globalConfig.synthetix.depositMarketUsd(marketId, address(this), amount);
+            globalConfig.synthetix.depositMarketUsd(marketId, msg.sender, amount);
         } else {
             ITokenModule synth = ITokenModule(globalConfig.spotMarket.getSynth(synthMarketId));
             synth.transferFrom(msg.sender, address(this), amount);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,7 +34,7 @@ const config = {
     publicSourceCode: false, // Should publish contract sources along with bytecode?
   },
   mocha: {
-    timeout: 10 * 1000, // 10s
+    timeout: 20 * 1000, // 20s
   },
   gasReporter: {
     enabled: !!process.env.REPORT_GAS,

--- a/test/assert.ts
+++ b/test/assert.ts
@@ -29,12 +29,9 @@ export const assertEvents = async (
 ) => {
   // TODO: Consider wrapping this in autoMine: false; .wait(); mine(); autoMine: true.
   const receipt = 'wait' in txOrReceipt ? await txOrReceipt.wait() : txOrReceipt;
-  const spaces = ' '.repeat(6); // to align with assert output
+  const spaces = ' '.repeat(6); // Used to align with assert output.
 
   const { logs } = receipt;
-  if (logs.length !== expected.length) {
-    throw new Error(`Expected ${expected.length} events, got ${logs.length}`);
-  }
   let seenEvents: string[] = [];
   const parsedLogs = logs.map((log, i) => {
     try {
@@ -50,6 +47,13 @@ export const assertEvents = async (
       );
     }
   });
+
+  if (logs.length !== expected.length) {
+    throw new Error(
+      `Expected ${expected.length} events, got ${logs.length}.\n${spaces}${seenEvents.join(`\n${spaces}`)}`
+    );
+  }
+
   parsedLogs.forEach((event, i) => {
     const expectedAtIndex = expected[i];
     if (typeof expectedAtIndex === 'string' ? event === expectedAtIndex : event.match(expectedAtIndex)) {

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -2,16 +2,9 @@ import { coreBootstrap } from '@synthetixio/router/dist/utils/tests';
 import { snapshotCheckpoint } from '@synthetixio/core-utils/utils/mocha/snapshot';
 import { createStakedPool } from '@synthetixio/main/test/common';
 import { bootstrapSynthMarkets } from '@synthetixio/spot-market/test/common';
-import {
-  PerpMarketProxy,
-  PerpAccountProxy,
-  SnxV3CollateralMock,
-  SynthetixCollateral2Mock,
-  PythMock,
-  AggregatorV3Mock,
-} from './generated/typechain';
+import { PerpMarketProxy, PerpAccountProxy, PythMock, AggregatorV3Mock } from './generated/typechain';
 import type { IMarketConfigurationModule } from './generated/typechain/MarketConfigurationModule';
-import { BigNumber, utils, Signer, constants, ethers } from 'ethers';
+import { BigNumber, utils, Signer, constants } from 'ethers';
 import { createOracleNode } from '@synthetixio/oracle-manager/test/common';
 import { CollateralMock } from '../typechain-types';
 import { bn, genOneOf } from './generators';
@@ -40,8 +33,8 @@ export interface Contracts {
   ['synthetix.oracle_manager.Proxy']: Systems['OracleManager'];
   ['spotMarket.SpotMarketProxy']: Systems['SpotMarket'];
   ['spotMarket.SynthRouter']: Systems['Synth'];
-  SnxV3CollateralMock: SnxV3CollateralMock;
-  SynthetixCollateral2Mock: SynthetixCollateral2Mock;
+  CollateralMock: CollateralMock;
+  Collateral2Mock: CollateralMock;
   PerpMarketProxy: PerpMarketProxy;
   PerpAccountProxy: PerpAccountProxy;
   PythMock: PythMock;
@@ -111,8 +104,8 @@ export const bootstrap = (args: GeneratedBootstrap) => {
       // follow the same ERC20 standard, simply named differently.
       //
       // `CollateralMock` is collateral deposited/delegated configured `args.markets`.
-      CollateralMock: getContract('SnxV3CollateralMock'),
-      Collateral2Mock: getContract('SynthetixCollateral2Mock'),
+      CollateralMock: getContract('CollateralMock'),
+      Collateral2Mock: getContract('Collateral2Mock'),
     };
   });
 
@@ -244,6 +237,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
     const nonSusdCollaterals = collaterals.map((collateral, idx): PerpCollateral => {
       const synthMarket = synthMarkets[idx];
       const synth = synthMarket.synth();
+
       return {
         ...collateral,
         contract: synth,
@@ -305,8 +299,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
       }
     }
 
-    // TODO: Replace `nonSusdCollaterals` with `allCollaterals` to start using sUSD.
-    collaterals = nonSusdCollaterals;
+    collaterals = allCollaterals;
     collateralsWithoutSusd = nonSusdCollaterals;
   });
 

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -11,7 +11,7 @@ import {
   AggregatorV3Mock,
 } from './generated/typechain';
 import type { IMarketConfigurationModule } from './generated/typechain/MarketConfigurationModule';
-import { BigNumber, utils, Signer, constants } from 'ethers';
+import { BigNumber, utils, Signer, constants, ethers } from 'ethers';
 import { createOracleNode } from '@synthetixio/oracle-manager/test/common';
 import { CollateralMock } from '../typechain-types';
 import { bn, genOneOf } from './generators';
@@ -75,6 +75,19 @@ export interface GeneratedBootstrap {
   }[];
 }
 
+export interface PerpCollateral {
+  name: string;
+  initialPrice: BigNumber;
+  max: BigNumber;
+  contract:
+    | Systems['USD']
+    | ReturnType<ReturnType<ReturnType<typeof bootstrapSynthMarkets>['synthMarkets']>[number]['synth']>;
+  synthMarketId: () => BigNumber;
+  synthAddress: () => string;
+  getPrice: () => ReturnType<AggregatorV3Mock['latestRoundData']>;
+  setPrice: (price: BigNumber) => Promise<void>;
+}
+
 export const bootstrap = (args: GeneratedBootstrap) => {
   const { getContract, getSigners, getProvider } = _bootstraped;
 
@@ -115,7 +128,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
   const stakedPool = createStakedPool(core, args.pool.stakedCollateralPrice, args.pool.stakedAmount);
 
   // Additional collaterals to provision as spot Synth markets.
-  const getCollaterals = () => [
+  const getRawCollaterals = () => [
     {
       name: 'swstETH',
       initialPrice: bn(genOneOf([1500, 1650, 1750, 1850, 4800])),
@@ -129,7 +142,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
   ];
 
   const spotMarket = bootstrapSynthMarkets(
-    getCollaterals().map(({ initialPrice, name }) => ({
+    getRawCollaterals().map(({ initialPrice, name }) => ({
       name,
       token: name,
       buyPrice: initialPrice,
@@ -142,38 +155,63 @@ export const bootstrap = (args: GeneratedBootstrap) => {
   //
   // NOTE: See below for the `before` block below on collateral management.
   const configureCollateral = async () => {
-    const collaterals = getCollaterals();
+    const collaterals = getRawCollaterals();
 
     // Amend sUSD as a collateral to configure.
+    const sUsdMaxAllowance = bn(10_000_000);
     const synthMarkets = spotMarket.synthMarkets();
-    const synthMarketIds = [SYNTHETIX_USD_MARKET_ID].concat(synthMarkets.map((market) => market.marketId()));
-    const maxAllowances = [bn(10_000_000)].concat(collaterals.map(({ max }) => max));
 
     // Allow this collateral to be depositable into the perp market.
+    const synthMarketIds = [SYNTHETIX_USD_MARKET_ID].concat(synthMarkets.map((market) => market.marketId()));
+    const maxAllowances = [sUsdMaxAllowance].concat(collaterals.map(({ max }) => max));
     await systems.PerpMarketProxy.connect(getOwner()).setCollateralConfiguration(synthMarketIds, maxAllowances);
 
-    // TODO: This should be abstracted such that sUSD can be generated and used for all tests.
-    return collaterals.map((collateral, idx) => {
+    // Collect non-sUSD collaterals along with their Synth Market.
+    const nonSusdCollaterals = collaterals.map((collateral, idx): PerpCollateral => {
       const synthMarket = synthMarkets[idx];
+      const synth = synthMarket.synth();
       return {
         ...collateral,
-        synthMarket,
-        contract: synthMarket.synth(),
+        contract: synth,
+        synthMarketId: () => synthMarket.marketId(),
+        synthAddress: () => synthMarket.synthAddress(),
         // Why `sellAggregator`? All of BFP only uses `quoteSellExactIn`, so we only need to mock the `sellAggregator`.
         // If we need to buy synths during tests and for whatever reason we cannot just mint with owner, then that can
         // still be referenced via `collateral.synthMarket.buyAggregator()`.
         //
         // @see: `spotMarket.contracts.storage.Price.getCurrentPriceData`
-        aggregator: synthMarket.sellAggregator,
+        getPrice: () => synthMarket.sellAggregator().latestRoundData(),
+        // Why `setPrice`?
+        //
         // If you only update the price of the sell aggregator, and try to close a losing position things might fail.
         // sellExactIn is called and will revert with Invalid prices, if they differ too much.
         // Adding a convenient method here to update the prices for both
-        updatePrice: async (price: BigNumber) => {
+        setPrice: async (price: BigNumber) => {
           await synthMarket.sellAggregator().mockSetCurrentPrice(price);
-          return synthMarket.buyAggregator().mockSetCurrentPrice(price);
+          await synthMarket.buyAggregator().mockSetCurrentPrice(price);
         },
       };
     });
+
+    // Mock a sUSD synth collateral so it can also be used as a random collateral.
+    //
+    // NOTE: The system recognises sUSD as $1 so this sUsdAggregator is really just a stub but will never
+    // be used in any capacity.
+    const { aggregator: sUsdAggregator } = await createOracleNode(getOwner(), bn(1), systems.OracleManager);
+    const sUsdCollateral: PerpCollateral = {
+      name: 'sUSD',
+      initialPrice: bn(1),
+      max: sUsdMaxAllowance,
+      contract: systems.USD,
+      synthMarketId: () => SYNTHETIX_USD_MARKET_ID,
+      synthAddress: () => systems.USD.address,
+      getPrice: () => sUsdAggregator.latestRoundData(),
+      setPrice: async (price: BigNumber) => {
+        await sUsdAggregator.mockSetCurrentPrice(price);
+      },
+    };
+
+    return { sUsdCollateral, nonSusdCollaterals };
   };
 
   before(
@@ -250,20 +288,26 @@ export const bootstrap = (args: GeneratedBootstrap) => {
     );
   });
 
-  let collaterals: Awaited<ReturnType<typeof configureCollateral>>;
+  let collaterals: PerpCollateral[];
+  let collateralsWithoutSusd: PerpCollateral[];
   before('configure margin collaterals and their prices', async () => {
-    collaterals = await configureCollateral();
+    const { sUsdCollateral, nonSusdCollaterals } = await configureCollateral();
+    const allCollaterals = [sUsdCollateral].concat(nonSusdCollaterals);
 
     // Ensure core system has enough capacity to deposit this collateral for perp market x.
-    for (const collateral of collaterals) {
+    for (const collateral of allCollaterals) {
       for (const market of markets) {
         await systems.Core.connect(getOwner()).configureMaximumMarketCollateral(
           market.marketId(),
-          collateral.synthMarket.synthAddress(),
+          collateral.synthAddress(),
           constants.MaxUint256
         );
       }
     }
+
+    // TODO: Swap this over to `allCollaterals` and automatically, all tests will consider sUSD.
+    collaterals = nonSusdCollaterals;
+    collateralsWithoutSusd = nonSusdCollaterals;
   });
 
   let keeper: Signer;
@@ -331,6 +375,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
     restore,
     markets: () => markets,
     collaterals: () => collaterals,
+    collateralsWithoutSusd: () => collateralsWithoutSusd,
     pool: () => ({
       id: stakedPool.poolId,
       stakerAccountId: stakedPool.accountId,

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -281,6 +281,7 @@ export const bootstrap = (args: GeneratedBootstrap) => {
 
     return { sUsdCollateral, nonSusdCollaterals };
   };
+
   let collaterals: PerpCollateral[];
   let collateralsWithoutSusd: PerpCollateral[];
 

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -255,10 +255,8 @@ export const bootstrap = (args: GeneratedBootstrap) => {
         // sellExactIn is called and will revert with Invalid prices, if they differ too much.
         // Adding a convenient method here to update the prices for both
         setPrice: async (price: BigNumber) => {
-          await Promise.all([
-            synthMarket.sellAggregator().mockSetCurrentPrice(price),
-            synthMarket.buyAggregator().mockSetCurrentPrice(price),
-          ]);
+          await synthMarket.sellAggregator().mockSetCurrentPrice(price);
+          await synthMarket.buyAggregator().mockSetCurrentPrice(price);
         },
       };
     });

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -149,7 +149,7 @@ export const genTrader = async (
   const marginUsdDepositAmount = !isNil(options?.desiredMarginUsdDepositAmount)
     ? wei(options?.desiredMarginUsdDepositAmount)
     : wei(genOneOf([1000, 5000, 10_000, 15_000]));
-  const { answer: collateralPrice } = await collateral.aggregator().latestRoundData();
+  const { answer: collateralPrice } = await collateral.getPrice();
   const collateralDepositAmount = marginUsdDepositAmount.div(collateralPrice).toBN();
 
   return {
@@ -163,10 +163,6 @@ export const genTrader = async (
     collateralPrice,
   };
 };
-
-/** Generate a non-USD collatearl */
-export const genNonUsdCollateral = ({ collaterals }: Bs) =>
-  genOneOf(collaterals().filter((x) => !x.synthMarket.marketId().eq(SYNTHETIX_USD_MARKET_ID)));
 
 /** Generates a side randomly, 1 for long, -1 for short. */
 export const genSide = (): 1 | -1 => genOneOf([1, -1]);
@@ -193,7 +189,7 @@ export const genOrder = async (
   // Use a reasonable amount of leverage.
   const leverage = options?.desiredLeverage ?? genOneOf([0.5, 1, 2, 3, 4, 5]);
 
-  const { answer: collateralPrice } = await collateral.aggregator().latestRoundData();
+  const { answer: collateralPrice } = await collateral.getPrice();
   const marginUsd = wei(collateralDepositAmount).mul(collateralPrice).sub(keeperFeeBufferUsd);
 
   const oraclePrice = await PerpMarketProxy.getOraclePrice(market.marketId());

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -4,7 +4,6 @@ import { shuffle, isNil, random } from 'lodash';
 import { wei } from '@synthetixio/wei';
 import { MARKETS } from './data/markets.fixture';
 import { Bs, Market, Trader, Collateral } from './typed';
-import { SYNTHETIX_USD_MARKET_ID } from './helpers';
 
 // --- Utils --- //
 

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -71,7 +71,7 @@ export const genBootstrap = () => ({
     maxOrderAge: 60,
     minKeeperFeeUsd: bn(genNumber(10, 15)),
     maxKeeperFeeUsd: bn(genNumber(50, 100)),
-    keeperProfitMarginPercent: wei(genNumber(0.1, 0.2)).toBN(),
+    keeperProfitMarginPercent: bn(genNumber(0.1, 0.2)),
     keeperSettlementGasUnits: 1_200_000,
     keeperLiquidationGasUnits: 1_200_000,
     keeperLiquidationFeeUsd: bn(genNumber(1, 5)),
@@ -244,7 +244,7 @@ export const genOrderFromSizeDelta = async (
   const { orderFee, keeperFee } = await PerpMarketProxy.getOrderFees(market.marketId(), sizeDelta, keeperFeeBufferUsd);
 
   return {
-    marginUsd: BigNumber.from(0),
+    marginUsd: bn(0),
     leverage: 0,
     keeperFeeBufferUsd,
     sizeDelta,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -187,13 +187,6 @@ export const commitAndSettle = async (
       }),
     provider()
   );
-  // TODO: Need to figure out if we can rely on wait (@joey).
-  //
-  // const tx = await PerpMarketProxy.connect(settlementKeeper).settleOrder(trader.accountId, marketId, [updateData], {
-  //   value: updateFee,
-  // });
-  // const receipt = await tx.wait();
-
   const lastBaseFeePerGas = (await provider().getFeeData()).lastBaseFeePerGas as BigNumber;
 
   return { tx, receipt, settlementTime, publishTime, lastBaseFeePerGas };

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -262,3 +262,8 @@ export const getSusdCollateral = (collaterals: PerpCollateral[]) => {
 };
 
 export const isSusdCollateral = (collateral: PerpCollateral) => collateral.synthMarketId() === SYNTHETIX_USD_MARKET_ID;
+
+export const findOrThrow = <A>(l: A[], p: (a: A) => boolean) => {
+  const found = l.find(p);
+  return found ? found : raise('Cannot find in l');
+};

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -26,7 +26,7 @@ export const mintAndApprove = async (
   const { PerpMarketProxy, SpotMarket } = systems();
 
   // NOTE: We `.mint` into the `trader.signer` before approving as only owners can mint.
-  const synth = collateral.synthMarket.synth();
+  const synth = collateral.contract;
   const synthOwnerAddress = await synth.owner();
 
   await provider().send('hardhat_impersonateAccount', [synthOwnerAddress]);
@@ -58,7 +58,7 @@ export const depositMargin = async (bs: Bs, gTrader: GeneratedTrader) => {
   await PerpMarketProxy.connect(trader.signer).modifyCollateral(
     trader.accountId,
     market.marketId(),
-    collateral.synthMarket.marketId(),
+    collateral.synthMarketId(),
     collateralDepositAmount
   );
 

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -1353,7 +1353,7 @@ describe('LiquidationModule', () => {
 
         const orderSide = genSide();
         const marginUsdDepositAmount = 15_000;
-        const collateral = collaterals()[0];
+        const collateral = collaterals()[0]; // sUSD
         const market = markets()[0];
         const marketId = market.marketId();
 

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -79,10 +79,13 @@ describe('LiquidationModule', () => {
       const { healthFactor } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
       assertBn.lte(healthFactor, bn(1));
 
-      const tx = await PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId);
+      const { receipt } = await withExplicitEvmMine(
+        () => PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId),
+        provider()
+      );
       const keeperAddress = await keeper().getAddress();
       await assertEvent(
-        tx,
+        receipt,
         `PositionFlaggedLiquidation(${trader.accountId}, ${marketId}, "${keeperAddress}", ${newMarketOraclePrice})`,
         PerpMarketProxy
       );
@@ -113,14 +116,17 @@ describe('LiquidationModule', () => {
         .toBN();
       await market.aggregator().mockSetCurrentPrice(newMarketOraclePrice);
 
-      const tx = await PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId);
+      const { receipt } = await withExplicitEvmMine(
+        () => PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId),
+        provider()
+      );
       const keeperAddress = await keeper().getAddress();
       await assertEvent(
-        tx,
+        receipt,
         `PositionFlaggedLiquidation(${trader.accountId}, ${marketId}, "${keeperAddress}", ${newMarketOraclePrice})`,
         PerpMarketProxy
       );
-      await assertEvent(tx, `OrderCanceled(${trader.accountId}, ${marketId}, ${commitmentTime})`, PerpMarketProxy);
+      await assertEvent(receipt, `OrderCanceled(${trader.accountId}, ${marketId}, ${commitmentTime})`, PerpMarketProxy);
     });
 
     it('should sell all available synth collateral for sUSD when flagging', async () => {
@@ -203,7 +209,7 @@ describe('LiquidationModule', () => {
       const { healthFactor } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
       assertBn.lte(healthFactor, bn(1));
 
-      const { tx, receipt } = await withExplicitEvmMine(
+      const { receipt } = await withExplicitEvmMine(
         () => PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId),
         provider()
       );
@@ -253,7 +259,7 @@ describe('LiquidationModule', () => {
         ]);
       }
 
-      await assertEvents(tx, expectedEvents, contractsWithAllEvents);
+      await assertEvents(receipt, expectedEvents, contractsWithAllEvents);
     });
 
     it('should revert when position already flagged', async () => {

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -76,7 +76,7 @@ describe('LiquidationModule', () => {
       await market.aggregator().mockSetCurrentPrice(newMarketOraclePrice);
 
       const { healthFactor } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
-      assertBn.lte(healthFactor, wei(1).toBN());
+      assertBn.lte(healthFactor, bn(1));
 
       const tx = await PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId);
       const keeperAddress = await keeper().getAddress();
@@ -428,13 +428,13 @@ describe('LiquidationModule', () => {
       );
 
       const { healthFactor: hf1 } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
-      assertBn.lt(hf1, wei(1).toBN());
+      assertBn.lt(hf1, bn(1));
       await PerpMarketProxy.connect(keeper()).flagPosition(trader.accountId, marketId);
 
       // Price moves back and they're no longer in liquidation but already flagged.
-      await market.aggregator().mockSetCurrentPrice(wei(marketOraclePrice).toBN());
+      await market.aggregator().mockSetCurrentPrice(marketOraclePrice);
       const { healthFactor: hf2 } = await PerpMarketProxy.getPositionDigest(trader.accountId, marketId);
-      assertBn.gt(hf2, wei(1).toBN());
+      assertBn.gt(hf2, bn(1));
 
       // Attempt the liquidate. This should complete successfully.
       const { tx, receipt } = await withExplicitEvmMine(
@@ -990,7 +990,7 @@ describe('LiquidationModule', () => {
 
         // Be quite explicit with what market and market params we are using to ensure a partial liquidation.
         const market = markets()[0];
-        await market.aggregator().mockSetCurrentPrice(wei(25_000).toBN());
+        await market.aggregator().mockSetCurrentPrice(bn(25_000));
         const orderSide = genSide();
 
         const { trader, marketId, collateral, collateralDepositAmount } = await depositMargin(
@@ -1279,9 +1279,7 @@ describe('LiquidationModule', () => {
           orders.push(order);
         }
 
-        const sizeToLiquidate = orders.reduce((acc, order) => {
-          return acc.add(order.sizeDelta.abs());
-        }, BigNumber.from(0));
+        const sizeToLiquidate = orders.reduce((acc, order) => acc.add(order.sizeDelta.abs()), bn(0));
 
         // Verify that liquidating both will not incur any caps.
         const capBefore = await PerpMarketProxy.getRemainingLiquidatableSizeCapacity(marketId);

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -32,6 +32,7 @@ import {
   BURN_ADDRESS,
   getSusdCollateral,
   isSusdCollateral,
+  findOrThrow,
 } from '../../helpers';
 import { Trader } from '../../typed';
 import { assertEvents } from '../../assert';
@@ -142,12 +143,12 @@ describe('LiquidationModule', () => {
 
       // Verify no USD but _some_ non-USD collateral was used as margin.
       const d1 = await PerpMarketProxy.getAccountDigest(trader.accountId, marketId);
-      const collateralBalanceBefore = d1.depositedCollaterals
-        .filter((c) => c.synthMarketId.eq(collateral.synthMarketId()))
-        .map((c) => c.available)[0];
-      const usdBalanceBefore = d1.depositedCollaterals
-        .filter((c) => c.synthMarketId.eq(SYNTHETIX_USD_MARKET_ID))
-        .map((c) => c.available)[0];
+      const collateralBalanceBefore = findOrThrow(d1.depositedCollaterals, (c) =>
+        c.synthMarketId.eq(collateral.synthMarketId())
+      ).available;
+      const usdBalanceBefore = findOrThrow(d1.depositedCollaterals, (c) =>
+        c.synthMarketId.eq(SYNTHETIX_USD_MARKET_ID)
+      ).available;
 
       assertBn.equal(collateralBalanceBefore, collateralDepositAmount);
       assertBn.isZero(usdBalanceBefore);
@@ -164,12 +165,12 @@ describe('LiquidationModule', () => {
       // Assert the collateral has been sold and all that's left is sUSD (minus fees).
       const d2 = await PerpMarketProxy.getAccountDigest(trader.accountId, marketId);
 
-      const collateralBalanceAfter = d2.depositedCollaterals
-        .filter((c) => c.synthMarketId.eq(collateral.synthMarketId()))
-        .map((c) => c.available)[0];
-      const usdBalanceAfter = d2.depositedCollaterals
-        .filter((c) => c.synthMarketId.eq(SYNTHETIX_USD_MARKET_ID))
-        .map((c) => c.available)[0];
+      const collateralBalanceAfter = findOrThrow(d2.depositedCollaterals, (c) =>
+        c.synthMarketId.eq(collateral.synthMarketId())
+      ).available;
+      const usdBalanceAfter = findOrThrow(d2.depositedCollaterals, (c) =>
+        c.synthMarketId.eq(SYNTHETIX_USD_MARKET_ID)
+      ).available;
 
       assertBn.isZero(collateralBalanceAfter);
       assertBn.near(usdBalanceAfter, marginUsdDepositAmount); // .near to account for spot-market skewFee.

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -257,13 +257,12 @@ describe('MarginModule', async () => {
           bs,
           await genTrader(bs, { desiredCollateral: getCollateral() })
         );
-        const { accountId, signer } = trader;
 
         // Perform the deposit.
         const { receipt } = await withExplicitEvmMine(
           () =>
-            PerpMarketProxy.connect(signer).modifyCollateral(
-              accountId,
+            PerpMarketProxy.connect(trader.signer).modifyCollateral(
+              trader.accountId,
               marketId,
               collateral.synthMarketId(),
               collateralDepositAmount
@@ -852,7 +851,7 @@ describe('MarginModule', async () => {
             trader.accountId,
             marketId,
             collateral.synthMarketId(),
-            wei(-0.01).toBN()
+            bn(-0.01)
           ),
           `CanLiquidatePosition()`,
           PerpMarketProxy
@@ -1035,7 +1034,7 @@ describe('MarginModule', async () => {
         await PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(trader.accountId, marketId);
         const actualBalance = await collateral.contract.balanceOf(traderAddress);
 
-        assertBn.lt(expectedChange.toBN(), wei(0).toBN());
+        assertBn.lt(expectedChange.toBN(), bn(0));
 
         assertBn.equal(actualBalance, startingCollateralBalance.add(expectedChange).toBN());
       });
@@ -1265,13 +1264,13 @@ describe('MarginModule', async () => {
         const balanceAfterTrade = await collateral.contract.balanceOf(traderAddress);
 
         // We expect to be losing.
-        assertBn.lt(collateralDiffAmount.toBN(), 0);
+        assertBn.lt(collateralDiffAmount.toBN(), bn(0));
 
         // Assert that the balance is correct.
         assertBn.equal(expectedCollateralBalanceAfterTrade, balanceAfterTrade);
 
         // Everything has been withdrawn. There should be no reportedDebt for this market.
-        assertBn.near(await PerpMarketProxy.reportedDebt(marketId), BigNumber.from(0), bn(0.00001));
+        assertBn.near(await PerpMarketProxy.reportedDebt(marketId), bn(0), bn(0.00001));
       });
 
       it('should revert with InsufficientMarketCollateralWithdrawable from synthetix.MarketCollateralModule');
@@ -1477,7 +1476,7 @@ describe('MarginModule', async () => {
       // Set zero allowable deposits.
       const supportedCollaterals = collaterals();
       const synthMarketIds = [supportedCollaterals[0].synthMarketId(), supportedCollaterals[1].synthMarketId()];
-      const maxAllowables = [BigNumber.from(0), BigNumber.from(0)];
+      const maxAllowables = [bn(0), bn(0)];
       await PerpMarketProxy.connect(from).setCollateralConfiguration(synthMarketIds, maxAllowables);
 
       // Depositing should cause a failure.
@@ -1634,7 +1633,7 @@ describe('MarginModule', async () => {
         .add(pnl);
 
       // Assert margin before price change
-      assertBn.near(marginUsdBeforePriceChange, expectedMarginUsdBeforePriceChange.toBN(), wei(0.000001).toBN());
+      assertBn.near(marginUsdBeforePriceChange, expectedMarginUsdBeforePriceChange.toBN(), bn(0.000001));
       // Change the price, this might lead to profit or loss, depending the the generated order is long or short
       const newPrice = wei(order.oraclePrice).mul(1.5).toBN();
       // Update price
@@ -1655,7 +1654,7 @@ describe('MarginModule', async () => {
         .add(accruedFunding);
 
       // Assert marginUSD after price update.
-      assertBn.near(marginUsdAfterPriceChange, expectedMarginUsdAfterPriceChange.toBN(), wei(0.000001).toBN());
+      assertBn.near(marginUsdAfterPriceChange, expectedMarginUsdAfterPriceChange.toBN(), bn(0.000001));
     });
 
     it('should return 0 for underwater position not yet flagged', async () => {

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -34,7 +34,7 @@ import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 
 describe('MarginModule', async () => {
   const bs = bootstrap(genBootstrap());
-  const { markets, collaterals, traders, owner, systems, provider, restore } = bs;
+  const { markets, collaterals, collateralsWithoutSusd, traders, owner, systems, provider, restore } = bs;
 
   beforeEach(restore);
 
@@ -1691,9 +1691,11 @@ describe('MarginModule', async () => {
 
     it('should reflect collateral price changes', async () => {
       const { PerpMarketProxy } = systems();
-      const { trader, marketId, collateral, collateralDepositAmount, collateralPrice } = await depositMargin(
+
+      const collateral = genOneOf(collateralsWithoutSusd());
+      const { trader, marketId, collateralDepositAmount, collateralPrice } = await depositMargin(
         bs,
-        genTrader(bs)
+        genTrader(bs, { desiredCollateral: collateral })
       );
 
       const marginUsdBeforePriceChange = await PerpMarketProxy.getMarginUsd(trader.accountId, marketId);

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -67,7 +67,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount.mul(-1)
           ),
         provider()
@@ -77,7 +77,7 @@ describe('MarginModule', async () => {
         `"${PerpMarketProxy.address}"`,
         `"${await trader.signer.getAddress()}"`,
         collateralDepositAmount,
-        collateral.synthMarket.marketId(),
+        collateral.synthMarketId(),
       ].join(', ');
 
       await assertEvent(receipt, `OrderCanceled()`, PerpMarketProxy);
@@ -96,7 +96,7 @@ describe('MarginModule', async () => {
         PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           market.marketId(),
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           amountDelta
         ),
         `ZeroAmount()`
@@ -122,7 +122,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             market.marketId(),
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount2
           ),
         provider()
@@ -160,7 +160,7 @@ describe('MarginModule', async () => {
         PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           marketId,
-          gTrader2.collateral.synthMarket.marketId(),
+          gTrader2.collateral.synthMarketId(),
           gTrader2.collateralDepositAmount
         ),
         `OrderFound()`
@@ -171,7 +171,7 @@ describe('MarginModule', async () => {
         PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           marketId,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           collateralDepositAmount.mul(-1)
         ),
         `OrderFound()`
@@ -197,7 +197,7 @@ describe('MarginModule', async () => {
         PerpMarketProxy.connect(trader2.signer).modifyCollateral(
           trader1.accountId,
           market.marketId(),
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           collateralDepositAmount
         ),
         `PermissionDenied("${trader1.accountId}", "${permission}", "${signerAddress}")`
@@ -224,7 +224,7 @@ describe('MarginModule', async () => {
             PerpMarketProxy.connect(trader.signer).modifyCollateral(
               trader.accountId,
               market.marketId(),
-              collateral.synthMarket.marketId(),
+              collateral.synthMarketId(),
               amountDelta
             ),
           provider()
@@ -234,7 +234,7 @@ describe('MarginModule', async () => {
           `"${traderAddress}"`,
           `"${PerpMarketProxy.address}"`,
           amountDelta,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
         await assertEvent(receipt, `MarginDeposit(${marginDepositEventProperties})`, PerpMarketProxy);
 
@@ -256,7 +256,7 @@ describe('MarginModule', async () => {
         const tx = await PerpMarketProxy.connect(signer).modifyCollateral(
           accountId,
           marketId,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           collateralDepositAmount
         );
 
@@ -270,7 +270,7 @@ describe('MarginModule', async () => {
 
         const marketCollateralDepositedEventProperties = [
           marketId,
-          `"${collateral.synthMarket.synthAddress()}"`,
+          `"${collateral.synthAddress()}"`,
           collateralDepositAmount,
           `"${PerpMarketProxy.address}"`,
         ].join(', ');
@@ -278,7 +278,7 @@ describe('MarginModule', async () => {
           `"${traderAddress}"`,
           `"${PerpMarketProxy.address}"`,
           collateralDepositAmount,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
         await assertEvents(
           tx,
@@ -337,7 +337,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             invalidAccountId,
             market.marketId(),
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             amountDelta
           ),
           `PermissionDenied("${invalidAccountId}"`
@@ -356,7 +356,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             invalidMarketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount
           ),
           `MarketNotFound("${invalidMarketId}")`,
@@ -398,7 +398,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             market.marketId(),
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             depositAmountDelta
           ),
           `MaxCollateralExceeded("${depositAmountDelta}", "${collateral.max}")`
@@ -424,7 +424,7 @@ describe('MarginModule', async () => {
         await PerpMarketProxy.connect(trader1.signer).modifyCollateral(
           trader1.accountId,
           market.marketId(),
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           depositAmountDelta1
         );
 
@@ -433,7 +433,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader2.signer).modifyCollateral(
             trader2.accountId,
             market.marketId(),
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             depositAmountDelta2
           ),
           `MaxCollateralExceeded("${depositAmountDelta2}", "${collateral.max}")`
@@ -457,7 +457,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             market.marketId(),
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             amountToDeposit
           ),
           `InsufficientAllowance("${amountToDeposit}", "${amountAvailable}")`
@@ -491,7 +491,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount
           ),
           `PositionFlagged()`,
@@ -514,7 +514,7 @@ describe('MarginModule', async () => {
             PerpMarketProxy.connect(trader.signer).modifyCollateral(
               trader.accountId,
               marketId,
-              collateral.synthMarket.marketId(),
+              collateral.synthMarketId(),
               collateralDepositAmount.mul(-1)
             ),
           provider()
@@ -524,7 +524,7 @@ describe('MarginModule', async () => {
           `"${PerpMarketProxy.address}"`,
           `"${traderAddress}"`,
           collateralDepositAmount,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
 
         await assertEvent(receipt, `MarginWithdraw(${marginWithdrawEventProperties})`, PerpMarketProxy);
@@ -544,7 +544,7 @@ describe('MarginModule', async () => {
         const tx = await PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           marketId,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           withdrawAmount.mul(-1)
         );
 
@@ -560,7 +560,7 @@ describe('MarginModule', async () => {
           `"${PerpMarketProxy.address}"`,
           `"${traderAddress}"`,
           withdrawAmount,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
 
         await assertEvents(
@@ -588,7 +588,7 @@ describe('MarginModule', async () => {
         const tx = await PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           marketId,
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           withdrawAmount
         );
 
@@ -596,7 +596,7 @@ describe('MarginModule', async () => {
           `"${PerpMarketProxy.address}"`,
           `"${traderAddress}"`,
           withdrawAmount.abs(), // Convert to positive because `Transfer` takes in abs(amount).
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
 
         await assertEvent(tx, `MarginWithdraw(${marginWithdrawEventProperties})`, PerpMarketProxy);
@@ -635,7 +635,7 @@ describe('MarginModule', async () => {
             PerpMarketProxy.connect(trader.signer).modifyCollateral(
               trader.accountId,
               marketId,
-              collateral.synthMarket.marketId(),
+              collateral.synthMarketId(),
               withdrawAmount.mul(-1).toBN()
             ),
           provider()
@@ -644,7 +644,7 @@ describe('MarginModule', async () => {
           `"${PerpMarketProxy.address}"`,
           `"${traderAddress}"`,
           withdrawAmount.toBN(),
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
         ].join(', ');
         await assertEvent(receipt, `MarginWithdraw(${marginWithdrawEventProperties})`, PerpMarketProxy);
 
@@ -663,7 +663,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             invalidAccountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount.mul(-1)
           ),
           `PermissionDenied("${invalidAccountId}"`,
@@ -681,7 +681,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             invalidMarketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount.mul(-1)
           ),
           `MarketNotFound("${invalidMarketId}")`,
@@ -715,7 +715,7 @@ describe('MarginModule', async () => {
         const withdrawAmount = collateralDepositAmount.add(bn(1)).mul(-1);
 
         const insufficientCollateralEventProperties = [
-          `"${collateral.synthMarket.marketId()}"`,
+          `"${collateral.synthMarketId()}"`,
           `"${collateralDepositAmount}"`,
           `"${withdrawAmount.mul(-1)}"`,
         ].join(', ');
@@ -724,7 +724,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             withdrawAmount
           ),
           `InsufficientCollateral(${insufficientCollateralEventProperties})`,
@@ -763,7 +763,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             amountToWithdraw.mul(-1).toBN()
           ),
           `InsufficientMargin()`,
@@ -789,7 +789,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount.mul(-1)
           ),
           `CanLiquidatePosition()`,
@@ -818,7 +818,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             wei(-0.01).toBN()
           ),
           `CanLiquidatePosition()`,
@@ -849,7 +849,7 @@ describe('MarginModule', async () => {
           PerpMarketProxy.connect(trader.signer).modifyCollateral(
             trader.accountId,
             marketId,
-            collateral.synthMarket.marketId(),
+            collateral.synthMarketId(),
             collateralDepositAmount.mul(-1)
           ),
           `PositionFlagged()`,
@@ -885,11 +885,11 @@ describe('MarginModule', async () => {
 
         const { available: collateralBalance = bn(0) } =
           accountDigest.depositedCollaterals.find(({ synthMarketId }) =>
-            synthMarketId.eq(collateral.synthMarket.marketId())
+            synthMarketId.eq(collateral.synthMarketId())
           ) || {};
         const { available: collateral2Balance = bn(0) } =
           accountDigest.depositedCollaterals.find(({ synthMarketId }) =>
-            synthMarketId.eq(collateral2.synthMarket.marketId())
+            synthMarketId.eq(collateral2.synthMarketId())
           ) || {};
 
         assertBn.equal(collateralBalance, collateralDepositAmount);
@@ -910,14 +910,14 @@ describe('MarginModule', async () => {
           receipt,
           `MarginWithdraw("${
             PerpMarketProxy.address
-          }", "${traderAddress}", ${collateralDepositAmount}, ${collateral.synthMarket.marketId()})`,
+          }", "${traderAddress}", ${collateralDepositAmount}, ${collateral.synthMarketId()})`,
           PerpMarketProxy
         );
         await assertEvent(
           receipt,
           `MarginWithdraw("${
             PerpMarketProxy.address
-          }", "${traderAddress}", ${collateralDepositAmount2}, ${collateral2.synthMarket.marketId()})`,
+          }", "${traderAddress}", ${collateralDepositAmount2}, ${collateral2.synthMarketId()})`,
           PerpMarketProxy
         );
 
@@ -925,11 +925,11 @@ describe('MarginModule', async () => {
         const accountDigestAfter = await PerpMarketProxy.getAccountDigest(trader.accountId, marketId);
         const { available: collateralBalanceAfter = bn(0) } =
           accountDigestAfter.depositedCollaterals.find(({ synthMarketId }) =>
-            synthMarketId.eq(collateral.synthMarket.marketId())
+            synthMarketId.eq(collateral.synthMarketId())
           ) || {};
         const { available: collateral2BalanceAfter = bn(0) } =
           accountDigestAfter.depositedCollaterals.find(({ synthMarketId }) =>
-            synthMarketId.eq(collateral2.synthMarket.marketId())
+            synthMarketId.eq(collateral2.synthMarketId())
           ) || {};
 
         assertBn.isZero(collateralBalanceAfter);
@@ -1149,7 +1149,7 @@ describe('MarginModule', async () => {
 
         // Change collateral price 10% win.
         const newCollateralPrice = wei(collateralPrice).mul(1.1);
-        await collateral.updatePrice(newCollateralPrice.toBN());
+        await collateral.setPrice(newCollateralPrice.toBN());
 
         const closeOrder = await genOrder(bs, market, collateral, collateralDepositAmount, {
           desiredSize: wei(openOrder.sizeDelta).mul(-1).toBN(),
@@ -1175,7 +1175,7 @@ describe('MarginModule', async () => {
         const pnl = calcPnl(openOrder.sizeDelta, closeOrder.fillPrice, openOrder.fillPrice);
         const openOrderFees = wei(openOrder.orderFee).add(openEventArgs?.keeperFee);
         const closeOrderFees = wei(closeOrder.orderFee).add(closeEventArgs?.keeperFee);
-        const collateralMarketId = collateral.synthMarket.marketId();
+        const collateralMarketId = collateral.synthMarketId();
         const [keeperAddress, blockTimestamp] = await Promise.all([
           bs.keeper().getAddress(),
           provider()
@@ -1244,7 +1244,7 @@ describe('MarginModule', async () => {
         assertBn.equal(expectedCollateralBalanceAfterTrade, balanceAfterTrade);
 
         // Everything has been withdrawn. There should be no reportedDebt for this market.
-        assertBn.isZero(await PerpMarketProxy.reportedDebt(marketId));
+        assertBn.near(await PerpMarketProxy.reportedDebt(marketId), BigNumber.from(0), bn(0.00001));
       });
 
       it('should revert with InsufficientMarketCollateralWithdrawable from synthetix.MarketCollateralModule');
@@ -1376,7 +1376,7 @@ describe('MarginModule', async () => {
       const { PerpMarketProxy } = systems();
       const from = owner();
 
-      const synthMarketIds = [collaterals()[0].synthMarket.marketId(), collaterals()[1].synthMarket.marketId()];
+      const synthMarketIds = [collaterals()[0].synthMarketId(), collaterals()[1].synthMarketId()];
       const maxAllowables = genListOf(genNumber(3, 10), () => bn(genNumber(10_000, 100_000)));
 
       await assertRevert(
@@ -1390,7 +1390,7 @@ describe('MarginModule', async () => {
       const from = owner();
 
       const newCollaterals = shuffle(collaterals());
-      const newSynthMarketIds = newCollaterals.map(({ synthMarket }) => synthMarket.marketId());
+      const newSynthMarketIds = newCollaterals.map(({ synthMarketId }) => synthMarketId());
       const newMaxAllowables = genListOf(newCollaterals.length, () => bn(genNumber(10_000, 100_000)));
 
       const tx = await PerpMarketProxy.connect(from).setCollateralConfiguration(newSynthMarketIds, newMaxAllowables);
@@ -1400,7 +1400,7 @@ describe('MarginModule', async () => {
 
       for (const [_i, configuredCollateral] of Object.entries(configuredCollaterals)) {
         const idx = parseInt(_i);
-        const synth = newCollaterals[idx].synthMarket.synth();
+        const synth = newCollaterals[idx].contract;
 
         const perpAllowance = await synth.allowance(PerpMarketProxy.address, PerpMarketProxy.address);
         const coreAllowance = await synth.allowance(PerpMarketProxy.address, bs.systems().Core.address);
@@ -1423,17 +1423,14 @@ describe('MarginModule', async () => {
 
       // Set a known set of supported collaterals.
       const supportedCollaterals = collaterals();
-      const synthMarketIds1 = [
-        supportedCollaterals[0].synthMarket.marketId(),
-        supportedCollaterals[1].synthMarket.marketId(),
-      ];
+      const synthMarketIds1 = [supportedCollaterals[0].synthMarketId(), supportedCollaterals[1].synthMarketId()];
       const maxAllowables1 = [BigNumber.from(1), BigNumber.from(1)];
       await PerpMarketProxy.connect(from).setCollateralConfiguration(synthMarketIds1, maxAllowables1);
 
       // Reconfigure the collaterals, removing one of them.
       const synthMarketIds2 = [
-        supportedCollaterals[0].synthMarket.marketId(),
-        // supportedCollaterals[1].synthMarket.marketId(), (removed!)
+        supportedCollaterals[0].synthMarketId(),
+        // supportedCollaterals[1].synthMarketId(), (removed!)
       ];
       const maxAllowables2 = [BigNumber.from(1)];
       await PerpMarketProxy.connect(from).setCollateralConfiguration(synthMarketIds2, maxAllowables2);
@@ -1441,7 +1438,7 @@ describe('MarginModule', async () => {
       const configuredCollaterals = await PerpMarketProxy.getConfiguredCollaterals();
       assert.equal(configuredCollaterals.length, 1);
       assert.equal(
-        configuredCollaterals.filter((c) => c.synthMarketId.eq(supportedCollaterals[1].synthMarket.marketId())).length,
+        configuredCollaterals.filter((c) => c.synthMarketId.eq(supportedCollaterals[1].synthMarketId())).length,
         0
       );
     });
@@ -1452,10 +1449,7 @@ describe('MarginModule', async () => {
 
       // Set zero allowable deposits.
       const supportedCollaterals = collaterals();
-      const synthMarketIds = [
-        supportedCollaterals[0].synthMarket.marketId(),
-        supportedCollaterals[1].synthMarket.marketId(),
-      ];
+      const synthMarketIds = [supportedCollaterals[0].synthMarketId(), supportedCollaterals[1].synthMarketId()];
       const maxAllowables = [BigNumber.from(0), BigNumber.from(0)];
       await PerpMarketProxy.connect(from).setCollateralConfiguration(synthMarketIds, maxAllowables);
 
@@ -1467,10 +1461,10 @@ describe('MarginModule', async () => {
         PerpMarketProxy.connect(trader.signer).modifyCollateral(
           trader.accountId,
           market.marketId(),
-          collateral.synthMarket.marketId(),
+          collateral.synthMarketId(),
           collateralDepositAmount
         ),
-        `UnsupportedCollateral("${collateral.synthMarket.marketId()}")`
+        `UnsupportedCollateral("${collateral.synthMarketId()}")`
       );
     });
 
@@ -1531,12 +1525,12 @@ describe('MarginModule', async () => {
       assertBn.near(await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId), marginUsdDepositAmount);
 
       // Change price.
-      await collateral.aggregator().mockSetCurrentPrice(wei(2).mul(collateralPrice).toBN());
+      await collateral.setPrice(wei(2).mul(collateralPrice).toBN());
       const actual = await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId);
 
       // Fetch the price of the synth, this is our expected collateral value.
       const { returnAmount: expected } = await SpotMarket.quoteSellExactIn(
-        collateral.synthMarket.marketId(),
+        collateral.synthMarketId(),
         collateralDepositAmount
       );
 
@@ -1624,6 +1618,7 @@ describe('MarginModule', async () => {
       const newPnl = calcPnl(order.sizeDelta, newPrice, order.fillPrice);
 
       const marginUsdAfterPriceChange = await PerpMarketProxy.getMarginUsd(trader.accountId, marketId);
+
       // Calculate expected margin
       const expectedMarginUsdAfterPriceChange = wei(order.marginUsd)
         .sub(order.orderFee)
@@ -1631,7 +1626,8 @@ describe('MarginModule', async () => {
         .add(order.keeperFeeBufferUsd)
         .add(newPnl)
         .add(accruedFunding);
-      // Assert marginUSD after price update
+
+      // Assert marginUSD after price update.
       assertBn.near(marginUsdAfterPriceChange, expectedMarginUsdAfterPriceChange.toBN(), wei(0.000001).toBN());
     });
 
@@ -1686,9 +1682,10 @@ describe('MarginModule', async () => {
       );
       await commitAndSettle(bs, otherDeposit.marketId, otherDeposit.trader, order);
 
-      // Assert that collateral is still the same
+      // Assert that collateral is still the same.
       const marginAfterTradeOnDiffMarket = await PerpMarketProxy.getMarginUsd(trader.accountId, marketId);
-      // Margin should stay unchanged
+
+      // Margin should stay unchanged.
       assertBn.equal(marginBeforeTradeOnDiffMarket, marginAfterTradeOnDiffMarket);
     });
 
@@ -1706,10 +1703,9 @@ describe('MarginModule', async () => {
       const newPrice = wei(collateralPrice)
         .mul(genOneOf([1.1, 0.9]))
         .toBN();
-      await collateral.aggregator().mockSetCurrentPrice(newPrice);
+      await collateral.setPrice(newPrice);
 
       const marginUsdAfterPriceChange = await PerpMarketProxy.getMarginUsd(trader.accountId, marketId);
-
       assertBn.equal(marginUsdAfterPriceChange, wei(collateralDepositAmount).mul(newPrice).toBN());
     });
 

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -1519,8 +1519,12 @@ describe('MarginModule', async () => {
 
     it('should return usd amount after price of collateral changes', async () => {
       const { PerpMarketProxy, SpotMarket } = systems();
-      const { trader, marketId, marginUsdDepositAmount, collateral, collateralPrice, collateralDepositAmount } =
-        await depositMargin(bs, genTrader(bs));
+
+      // We can't use sUSD here because it should alwyas be 1 within the system.
+      const collateral = genOneOf(collateralsWithoutSusd());
+
+      const { trader, marketId, marginUsdDepositAmount, collateralPrice, collateralDepositAmount } =
+        await depositMargin(bs, genTrader(bs, { desiredCollateral: collateral }));
 
       assertBn.near(await PerpMarketProxy.getCollateralUsd(trader.accountId, marketId), marginUsdDepositAmount);
 

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -63,12 +63,7 @@ describe('OrderModule', () => {
 
       // It's a little weird to get the event that we're asserting. We're doing this to get the correct base fee, anvil
       // have some issue with consistent base fee, which keeperFee is based on.
-      const { args: orderCommittedArgs } =
-        findEventSafe({
-          receipt,
-          eventName: 'OrderCommitted',
-          contract: PerpMarketProxy,
-        }) || {};
+      const { args: orderCommittedArgs } = findEventSafe(receipt, 'OrderCommitted', PerpMarketProxy) || {};
 
       const orderCommittedEventProperties = [
         trader.accountId,
@@ -397,13 +392,7 @@ describe('OrderModule', () => {
       const block = await provider().getBlock(receipt.blockNumber);
       const timestamp = block.timestamp;
 
-      const { args: orderSettledArgs } =
-        findEventSafe({
-          receipt,
-          eventName: 'OrderSettled',
-          contract: PerpMarketProxy,
-        }) || {};
-
+      const { args: orderSettledArgs } = findEventSafe(receipt, 'OrderSettled', PerpMarketProxy) || {};
       const orderSettledEventProperties = [
         trader.accountId,
         marketId,
@@ -704,12 +693,7 @@ describe('OrderModule', () => {
         desiredKeeper: keeper(),
       });
 
-      const keeperFee = findEventSafe({
-        receipt,
-        eventName: 'OrderSettled',
-        contract: PerpMarketProxy,
-      })?.args.keeperFee;
-
+      const keeperFee = findEventSafe(receipt, 'OrderSettled', PerpMarketProxy)?.args.keeperFee;
       assertBn.gt(keeperFee, BigNumber.from(0));
       assertBn.equal(await USD.balanceOf(await keeper().getAddress()), keeperFee);
     });
@@ -1175,11 +1159,7 @@ describe('OrderModule', () => {
     // @see: https://github.com/NomicFoundation/hardhat/issues/3028
     describe.skip('keeperFee', () => {
       const getKeeperFee = (PerpMarketProxy: PerpMarketProxy, receipt: ethers.ContractReceipt): BigNumber =>
-        findEventSafe({
-          receipt,
-          eventName: 'OrderSettled',
-          contract: PerpMarketProxy,
-        })?.args.keeperFee;
+        findEventSafe(receipt, 'OrderSettled', PerpMarketProxy)?.args.keeperFee;
 
       it('should calculate keeper fees proportional to block.baseFee and profit margin', async () => {
         const { PerpMarketProxy } = systems();

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -655,7 +655,7 @@ describe('OrderModule', () => {
       // sUSD must be gt 0.
       assertBn.gt(
         d1.depositedCollaterals.filter(({ synthMarketId }) => synthMarketId.eq(SYNTHETIX_USD_MARKET_ID))[0].available,
-        BigNumber.from(0)
+        bn(0)
       );
 
       // Value of original collateral should also stay the same.
@@ -694,7 +694,7 @@ describe('OrderModule', () => {
       });
 
       const keeperFee = findEventSafe(receipt, 'OrderSettled', PerpMarketProxy)?.args.keeperFee;
-      assertBn.gt(keeperFee, BigNumber.from(0));
+      assertBn.gt(keeperFee, bn(0));
       assertBn.equal(await USD.balanceOf(await keeper().getAddress()), keeperFee);
     });
 
@@ -953,11 +953,11 @@ describe('OrderModule', () => {
               return getPythPriceData(bs, marketId, publishTime, 0);
             case ZeroPriceVariant.CL: {
               const oraclePrice = wei(order.oraclePrice).toNumber();
-              await market.aggregator().mockSetCurrentPrice(BigNumber.from(0));
+              await market.aggregator().mockSetCurrentPrice(bn(0));
               return getPythPriceData(bs, marketId, publishTime, oraclePrice);
             }
             case ZeroPriceVariant.BOTH: {
-              await market.aggregator().mockSetCurrentPrice(BigNumber.from(0));
+              await market.aggregator().mockSetCurrentPrice(bn(0));
               return getPythPriceData(bs, marketId, publishTime, 0);
             }
           }
@@ -1065,7 +1065,7 @@ describe('OrderModule', () => {
         });
 
         // Retrieve fees associated with this new order.
-        const { orderFee } = await PerpMarketProxy.getOrderFees(marketId, order2.sizeDelta, BigNumber.from(0));
+        const { orderFee } = await PerpMarketProxy.getOrderFees(marketId, order2.sizeDelta, bn(0));
         const { orderFee: expectedOrderFee } = await calcOrderFees(
           bs,
           marketId,
@@ -1224,14 +1224,14 @@ describe('OrderModule', () => {
         const { PerpMarketProxy } = systems();
 
         // Lower the min requirements to reduce fees fairly significantly.
-        const minKeeperFeeUsd = wei(60).toBN();
+        const minKeeperFeeUsd = bn(60);
         await setMarketConfiguration(bs, {
           keeperSettlementGasUnits: 100_000,
-          maxKeeperFeeUsd: wei(100).toBN(),
+          maxKeeperFeeUsd: bn(100),
           minKeeperFeeUsd,
-          keeperProfitMarginPercent: wei(0).toBN(),
+          keeperProfitMarginPercent: bn(0),
         });
-        await ethOracleNode().agg.mockSetCurrentPrice(wei(100).toBN()); // $100 ETH
+        await ethOracleNode().agg.mockSetCurrentPrice(bn(100)); // $100 ETH
 
         const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(
           bs,
@@ -1259,10 +1259,10 @@ describe('OrderModule', () => {
   describe('getFillPrice', () => {
     it('should revert invalid market id', async () => {
       const { PerpMarketProxy } = systems();
-      const invalidMarketId = wei(42069).toBN();
+      const invalidMarketId = bn(42069);
 
       // Size to check fill price
-      const size = wei(genNumber(-10, 10)).toBN();
+      const size = bn(genNumber(-10, 10));
 
       assertRevert(PerpMarketProxy.getFillPrice(invalidMarketId, size), `MarketNotFound("${invalidMarketId}")`);
     });
@@ -1283,7 +1283,7 @@ describe('OrderModule', () => {
       const oraclePrice = await PerpMarketProxy.getOraclePrice(marketId);
 
       // Using size to simulate short which will reduce the skew.
-      const size = wei(genNumber(1, 10)).toBN();
+      const size = bn(genNumber(1, 10));
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
 
@@ -1331,7 +1331,7 @@ describe('OrderModule', () => {
       const marketSkew = order.sizeDelta;
 
       // Size to check fill price.
-      const size = wei(0).toBN();
+      const size = bn(0);
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
       const expectedFillPrice = wei(1).add(wei(marketSkew).div(skewScale)).mul(oraclePrice).toBN();
@@ -1354,7 +1354,7 @@ describe('OrderModule', () => {
       const marketSkew = order.sizeDelta;
 
       // Size to check fill price.
-      const size = wei(genNumber(-10, 10)).toBN();
+      const size = bn(genNumber(-10, 10));
 
       const actualFillPrice = await PerpMarketProxy.getFillPrice(marketId, size);
       const expectedFillPrice = calcFillPrice(marketSkew, skewScale, size, oraclePrice);

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -1097,16 +1097,16 @@ describe('OrderModule', () => {
 
         // Use explicit values to test a concrete example.
         const trader = traders()[0];
-        const collateral = collaterals()[0];
+        const collateral = collateralsWithoutSusd()[0];
         const market = markets()[0];
-        const marginUsdDepositAmount = wei(1000).toBN();
+        const marginUsdDepositAmount = bn(1000);
         const leverage = 1;
         const keeperFeeBufferUsd = 0;
-        const collateralDepositAmount = wei(10).toBN();
-        const collateralPrice = wei(100).toBN();
-        const marketOraclePrice = wei(1).toBN();
-        const makerFee = wei(0.01).toBN();
-        const takerFee = wei(0.02).toBN();
+        const collateralDepositAmount = bn(10);
+        const collateralPrice = bn(100);
+        const marketOraclePrice = bn(1);
+        const makerFee = bn(0.01);
+        const takerFee = bn(0.02);
 
         // Update state to reflect explicit values.
         await collateral.setPrice(collateralPrice);
@@ -1213,11 +1213,11 @@ describe('OrderModule', () => {
         const { PerpMarketProxy } = systems();
 
         // Set a really high ETH price of 4.9k USD (Dec 21' ATH).
-        await ethOracleNode().agg.mockSetCurrentPrice(wei(4900).toBN());
+        await ethOracleNode().agg.mockSetCurrentPrice(bn(4900));
 
         // Cap the max keeperFee to $50 USD
-        const maxKeeperFeeUsd = wei(50).toBN();
-        await setMarketConfiguration(bs, { maxKeeperFeeUsd, minKeeperFeeUsd: wei(10).toBN() });
+        const maxKeeperFeeUsd = bn(50);
+        await setMarketConfiguration(bs, { maxKeeperFeeUsd, minKeeperFeeUsd: bn(10) });
 
         const { trader, marketId, market, collateral, collateralDepositAmount } = await depositMargin(
           bs,

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -511,10 +511,10 @@ describe('PerpMarketFactoryModule', () => {
         keeperProfitMarginPercent: BigNumber.from(0),
         maxKeeperFeeUsd: BigNumber.from(0),
       });
-      await SpotMarket.connect(signers()[2]).setMarketSkewScale(collateral.synthMarket.marketId(), BigNumber.from(0));
+      await SpotMarket.connect(signers()[2]).setMarketSkewScale(collateral.synthMarketId(), BigNumber.from(0));
 
       await market.aggregator().mockSetCurrentPrice(bn(2000));
-      await collateral.updatePrice(bn(1));
+      await collateral.setPrice(bn(1));
 
       // Deposit 1k USD worth of collateral into market for accountId.
       const { collateralDepositAmount, marginUsdDepositAmount } = await depositMargin(

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -164,40 +164,40 @@ describe('PerpMarketFactoryModule', () => {
 
         // Configure funding and velocity specific parameters so we get deterministic results.
         await setMarketConfigurationById(bs, market.marketId(), {
-          skewScale: wei(100_000).toBN(),
-          maxFundingVelocity: wei(0.25).toBN(),
-          maxMarketSize: wei(500_000).toBN(),
+          skewScale: bn(100_000),
+          maxFundingVelocity: bn(0.25),
+          maxMarketSize: bn(500_000),
         });
 
         // Set the market price as funding is denominated in USD.
-        const marketOraclePrice = wei(100).toBN();
+        const marketOraclePrice = bn(100);
         await market.aggregator().mockSetCurrentPrice(marketOraclePrice);
 
         // A static list of traders and amount of time to pass by trader and its expected funding.
         const trades = [
           // skew = long, r = (t 1000, s 1000)
           {
-            sizeDelta: wei(1000).toBN(),
+            sizeDelta: bn(1000),
             account: trader1,
             fastForwardInSec: 1000,
-            expectedFundingRate: BigNumber.from(0),
-            expectedFundingVelocity: wei(0.0025).toBN(),
+            expectedFundingRate: bn(0),
+            expectedFundingVelocity: bn(0.0025),
           },
           // skew = even more long, r = (t 30000, s 3000)
           {
-            sizeDelta: wei(2000).toBN(),
+            sizeDelta: bn(2000),
             account: trader2,
             fastForwardInSec: 29_000,
-            expectedFundingRate: wei(0.00083912).toBN(),
-            expectedFundingVelocity: wei(0.0075).toBN(),
+            expectedFundingRate: bn(0.00083912),
+            expectedFundingVelocity: bn(0.0075),
           },
           // skew = balanced but funding rate sticks, r (t 50000, s 0)
           {
-            sizeDelta: wei(-3000).toBN(),
+            sizeDelta: bn(-3000),
             account: trader3,
             fastForwardInSec: 20_000,
-            expectedFundingRate: wei(0.00257546).toBN(),
-            expectedFundingVelocity: BigNumber.from(0),
+            expectedFundingRate: bn(0.00257546),
+            expectedFundingVelocity: bn(0),
           },
           // See below for one final fundingRate observation without a trade (no change in rate).
         ];
@@ -210,7 +210,7 @@ describe('PerpMarketFactoryModule', () => {
           1_500_000 // 1.5M USD margin
         );
 
-        let lastFundingRate = BigNumber.from(0);
+        let lastFundingRate = bn(0);
         const { minOrderAge } = await PerpMarketProxy.getMarketConfiguration();
 
         for (const trade of trades) {
@@ -224,7 +224,7 @@ describe('PerpMarketFactoryModule', () => {
 
           const { fundingVelocity, fundingRate } = await PerpMarketProxy.getMarketDigest(market.marketId());
 
-          assertBn.near(fundingRate, expectedFundingRate, wei(0.000001).toBN());
+          assertBn.near(fundingRate, expectedFundingRate, bn(0.000001));
           assertBn.equal(fundingVelocity, expectedFundingVelocity);
 
           lastFundingRate = fundingRate;
@@ -235,7 +235,7 @@ describe('PerpMarketFactoryModule', () => {
         const { fundingVelocity, fundingRate } = await PerpMarketProxy.getMarketDigest(market.marketId());
 
         assertBn.equal(fundingRate, lastFundingRate);
-        assertBn.equal(fundingVelocity, BigNumber.from(0));
+        assertBn.equal(fundingVelocity, bn(0));
       });
 
       it('should demonstrate a balance market can have a non-zero funding', async () => {
@@ -255,7 +255,7 @@ describe('PerpMarketFactoryModule', () => {
         );
 
         // Open a position for trader1.
-        const sizeDelta = wei(genOneOf([genNumber(1, 10), genNumber(-10, -1)])).toBN();
+        const sizeDelta = bn(genOneOf([genNumber(1, 10), genNumber(-10, -1)]));
 
         const order1 = await genOrderFromSizeDelta(bs, market, sizeDelta, { desiredKeeperFeeBufferUsd: 0 });
         await commitAndSettle(bs, market.marketId(), trader1, order1);
@@ -310,16 +310,16 @@ describe('PerpMarketFactoryModule', () => {
         );
 
         // Go short.
-        const order1 = await genOrderFromSizeDelta(bs, market, wei(genNumber(-10, -1)).toBN(), {
+        const order1 = await genOrderFromSizeDelta(bs, market, bn(genNumber(-10, -1)), {
           desiredKeeperFeeBufferUsd: 0,
         });
         await commitAndSettle(bs, market.marketId(), trader, order1);
         await fastForwardBySec(provider(), SECONDS_ONE_DAY);
         const d1 = await PerpMarketProxy.getMarketDigest(market.marketId());
-        assertBn.lt(d1.fundingRate, BigNumber.from(0));
+        assertBn.lt(d1.fundingRate, bn(0));
 
         // Go long.
-        const order2 = await genOrderFromSizeDelta(bs, market, wei(genNumber(11, 20)).toBN(), {
+        const order2 = await genOrderFromSizeDelta(bs, market, bn(genNumber(11, 20)), {
           desiredKeeperFeeBufferUsd: 0,
         });
         await commitAndSettle(bs, market.marketId(), trader, order2);
@@ -337,7 +337,7 @@ describe('PerpMarketFactoryModule', () => {
         const collateral = genOneOf(collaterals());
 
         // Set the price of market oracle to be something relatively small to avoid hitting insufficient margin.
-        await market.aggregator().mockSetCurrentPrice(wei(genNumber(50, 100)).toBN());
+        await market.aggregator().mockSetCurrentPrice(bn(genNumber(50, 100)));
 
         const marginUsdDepositAmount = 500_000; // 500k USD.
         const { trader } = await depositMargin(
@@ -352,10 +352,10 @@ describe('PerpMarketFactoryModule', () => {
         // Velocity is skew/skewScale * maxVelocity. So in order in order to get max velocity of 1 * max then
         // skew must be equal to skewScale. Here we force the size to equal skewScale to test that it's capped
         // at and above.
-        const skewScale = wei(1000).toBN();
+        const skewScale = bn(1000);
         await setMarketConfigurationById(bs, market.marketId(), { skewScale });
         const sizeSide = side === 'long' ? 1 : -1;
-        const sizeDelta = skewScale.add(wei(genNumber(1, 10)).toBN()).mul(sizeSide);
+        const sizeDelta = skewScale.add(bn(genNumber(1, 10))).mul(sizeSide);
 
         const order = await genOrderFromSizeDelta(bs, market, sizeDelta, {
           desiredKeeperFeeBufferUsd: 0,
@@ -388,7 +388,7 @@ describe('PerpMarketFactoryModule', () => {
           );
 
           const sizeSide = side === 'long' ? 1 : -1;
-          const sizeDelta = wei(genNumber(1, 10)).mul(sizeSide).toBN();
+          const sizeDelta = bn(genNumber(1, 10)).mul(sizeSide);
 
           const order = await genOrderFromSizeDelta(bs, market, sizeDelta, {
             desiredKeeperFeeBufferUsd: 0,
@@ -414,7 +414,7 @@ describe('PerpMarketFactoryModule', () => {
     const getTotalPositionPnl = async (traders: Trader[], marketId: BigNumber) => {
       const { PerpMarketProxy } = systems();
       const positions = await Promise.all(traders.map((t) => PerpMarketProxy.getPositionDigest(t.accountId, marketId)));
-      return positions.reduce((acc, p) => acc.add(p.pnl).sub(p.accruedFeesUsd), BigNumber.from(0));
+      return positions.reduce((acc, p) => acc.add(p.pnl).sub(p.accruedFeesUsd), bn(0));
     };
 
     it('should have a debt of zero when first initialized', async () => {
@@ -462,7 +462,7 @@ describe('PerpMarketFactoryModule', () => {
       const { PerpMarketProxy } = systems();
 
       const reportedDebts: BigNumber[] = [];
-      let accumulatedReportedDebt = BigNumber.from(0);
+      let accumulatedReportedDebt = bn(0);
       for (const market of markets()) {
         const { trader, marketId, collateral, collateralDepositAmount } = await depositMargin(
           bs,
@@ -504,16 +504,16 @@ describe('PerpMarketFactoryModule', () => {
 
       // Create a frictionless market for simplicity.
       await setMarketConfigurationById(bs, marketId, {
-        makerFee: BigNumber.from(0),
-        takerFee: BigNumber.from(0),
-        maxFundingVelocity: BigNumber.from(0),
+        makerFee: bn(0),
+        takerFee: bn(0),
+        maxFundingVelocity: bn(0),
         skewScale: bn(1_000_000_000), // An extremely large skewScale to minimise price impact.
       });
       await setMarketConfiguration(bs, {
-        keeperProfitMarginPercent: BigNumber.from(0),
-        maxKeeperFeeUsd: BigNumber.from(0),
+        keeperProfitMarginPercent: bn(0),
+        maxKeeperFeeUsd: bn(0),
       });
-      await SpotMarket.connect(signers()[2]).setMarketSkewScale(collateral.synthMarketId(), BigNumber.from(0));
+      await SpotMarket.connect(signers()[2]).setMarketSkewScale(collateral.synthMarketId(), bn(0));
 
       await market.aggregator().mockSetCurrentPrice(bn(2000));
       await collateral.setPrice(bn(1));
@@ -552,7 +552,7 @@ describe('PerpMarketFactoryModule', () => {
       //           = 0
       await commitAndSettle(bs, marketId, trader, openOrder);
       assertBn.near(await PerpMarketProxy.reportedDebt(marketId), bn(1000), bn(0.0001));
-      assertBn.near(await Core.getMarketTotalDebt(marketId), BigNumber.from(0), bn(0.0001));
+      assertBn.near(await Core.getMarketTotalDebt(marketId), bn(0), bn(0.0001));
 
       // Market does a 2x. Debt should increase appropriately.
       //
@@ -590,7 +590,7 @@ describe('PerpMarketFactoryModule', () => {
       //           = 0 + 1000 - 0
       //           = 1000
       await PerpMarketProxy.connect(trader.signer).withdrawAllCollateral(trader.accountId, marketId);
-      assertBn.near(await PerpMarketProxy.reportedDebt(marketId), BigNumber.from(0), bn(0.0001));
+      assertBn.near(await PerpMarketProxy.reportedDebt(marketId), bn(0), bn(0.0001));
       assertBn.near(await Core.getMarketTotalDebt(marketId), bn(1000), bn(0.0001));
     });
 

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -34,7 +34,7 @@ import { shuffle, times } from 'lodash';
 
 describe('PerpMarketFactoryModule', () => {
   const bs = bootstrap(genBootstrap());
-  const { traders, signers, owner, markets, collaterals, systems, provider, restore } = bs;
+  const { traders, signers, owner, markets, collaterals, collateralsWithoutSusd, systems, provider, restore } = bs;
 
   beforeEach(restore);
 
@@ -492,10 +492,12 @@ describe('PerpMarketFactoryModule', () => {
 
     it('should expect sum of remaining all pnl to eq debt after a long period of trading');
 
-    it('should expect reportedDebt/totalDebt to be calculated correctly (concrete)', async () => {
+    it('should expect reportedDebt/totalDebt to be updated appropriately sUSD (concrete)');
+
+    it('should expect reportedDebt/totalDebt to be updated appropriately non-sUSD (concrete)', async () => {
       const { PerpMarketProxy, Core, SpotMarket } = systems();
 
-      const collateral = collaterals()[0];
+      const collateral = collateralsWithoutSusd()[0];
       const market = markets()[1]; // ETHPERP.
       const marketId = market.marketId();
       const trader = traders()[0];


### PR DESCRIPTION
- Minor abstraction to help with adding sUSD as a collateral type for `genOneOf(collaterals())`
- Adds a collateralsWithoutSusd for tests that explicitly require non sUSD collateral to continue operating
- Updates to all tests to ensure they are using the new abstraction
- Resolves a bug with sUSD margin deposits

```
  184 passing (50s)
  55 pending
```

👀 