### PR TITLE
Add setCollateralMaxAllowable

### DIFF
--- a/contracts/interfaces/IMarginModule.sol
+++ b/contracts/interfaces/IMarginModule.sol
@@ -53,6 +53,11 @@ interface IMarginModule is IBasePerpMarket {
      */
     function setCollateralConfiguration(uint128[] calldata synthMarketIds, uint128[] calldata maxAllowables) external;
 
+    /**
+     * @notice Set max allowables for existing collateral
+     */
+    function setCollateralMaxAllowable(uint128 synthMarketId, uint128 maxAllowable) external;
+
     // --- Views --- //
 
     /**

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -261,6 +261,27 @@ contract MarginModule is IMarginModule {
     /**
      * @inheritdoc IMarginModule
      */
+    function setCollateralMaxAllowable(uint128 synthMarketId, uint128 maxAllowable) external {
+        OwnableStorage.onlyOwner();
+
+        Margin.GlobalData storage globalMarginConfig = Margin.load();
+        uint256 length = globalMarginConfig.supportedSynthMarketIds.length;
+        for (uint256 i = 0; i < length; ) {
+            uint128 currentSynthMarketId = globalMarginConfig.supportedSynthMarketIds[i];
+            if (currentSynthMarketId == synthMarketId) {
+                globalMarginConfig.supported[currentSynthMarketId].maxAllowable = maxAllowable;
+                return;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        revert ErrorUtil.UnsupportedCollateral(synthMarketId);
+    }
+
+    /**
+     * @inheritdoc IMarginModule
+     */
     function setCollateralConfiguration(uint128[] calldata synthMarketIds, uint128[] calldata maxAllowables) external {
         OwnableStorage.onlyOwner();
 


### PR DESCRIPTION
A convenient method to set max allowable for a single collateral, rather than having to "reconfigure" all collateral.
Based on M-03-config-validation and could maybe even be part of that