### PR TITLE
Refactor/collateral consistency

### DIFF
--- a/contracts/interfaces/IMarginModule.sol
+++ b/contracts/interfaces/IMarginModule.sol
@@ -85,7 +85,7 @@ interface IMarginModule is IBasePerpMarket {
     function getMarginUsd(uint128 accountId, uint128 marketId) external view returns (uint256);
 
     /**
-     * @notice Returns the discount adjusted oracle price based on a given size.
+     * @notice Returns the discount adjusted oracle price based on `amount` of synth by `synthMarketId`.
      */
-    function getDiscountedCollateralPrice(uint128 marketId, int256 size) external view returns (uint256);
+    function getDiscountedCollateralPrice(uint128 synthMarketId, uint256 amount) external view returns (uint256);
 }

--- a/contracts/interfaces/IMarginModule.sol
+++ b/contracts/interfaces/IMarginModule.sol
@@ -85,7 +85,7 @@ interface IMarginModule is IBasePerpMarket {
     function getMarginUsd(uint128 accountId, uint128 marketId) external view returns (uint256);
 
     /**
-     * @notice Returns a haircut adjusted oracle price based on a given size.
+     * @notice Returns the discount adjusted oracle price based on a given size.
      */
-    function getHaircutCollateralPrice(uint128 marketId, int256 size) external view returns (uint256);
+    function getDiscountedCollateralPrice(uint128 marketId, int256 size) external view returns (uint256);
 }

--- a/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/contracts/interfaces/IMarketConfigurationModule.sol
@@ -24,6 +24,7 @@ interface IMarketConfigurationModule {
         uint256 keeperLiquidationFeeUsd;
         uint128 keeperFlagGasUnits;
         address keeperLiquidationEndorsed;
+        uint128 spotMarketSkewScaleScalar;
         uint128 minCollateralDiscount;
         uint128 maxCollateralDiscount;
         uint128 sellExactInMaxSlippagePercent;

--- a/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/contracts/interfaces/IMarketConfigurationModule.sol
@@ -24,8 +24,8 @@ interface IMarketConfigurationModule {
         uint256 keeperLiquidationFeeUsd;
         uint128 keeperFlagGasUnits;
         address keeperLiquidationEndorsed;
-        uint128 minCollateralHaircut;
-        uint128 maxCollateralHaircut;
+        uint128 minCollateralDiscount;
+        uint128 maxCollateralDiscount;
         uint128 sellExactInMaxSlippagePercent;
         uint128 utilizationBreakpointPercent;
         uint128 lowUtilizationSlopePercent;

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -180,7 +180,7 @@ contract LiquidationModule is ILiquidationModule {
         uint256 oraclePrice = market.getOraclePrice();
         bool isLiquidatable = position.isLiquidatable(
             market,
-            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useHaircutCollateralPrice */),
+            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useDiscountedCollateralPrice */),
             oraclePrice,
             PerpMarketConfiguration.load(marketId)
         );
@@ -323,7 +323,7 @@ contract LiquidationModule is ILiquidationModule {
         return
             market.positions[accountId].isLiquidatable(
                 market,
-                Margin.getMarginUsd(accountId, market, oraclePrice, true /* useHaircutCollateralPrice */),
+                Margin.getMarginUsd(accountId, market, oraclePrice, true /* useDiscountedCollateralPrice */),
                 oraclePrice,
                 PerpMarketConfiguration.load(marketId)
             );
@@ -361,7 +361,7 @@ contract LiquidationModule is ILiquidationModule {
             position.entryPrice,
             position.entryFundingAccrued,
             position.entryUtilizationAccrued,
-            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useHaircutCollateralPrice */),
+            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useDiscountedCollateralPrice */),
             oraclePrice,
             PerpMarketConfiguration.load(marketId)
         );

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -283,8 +283,9 @@ contract LiquidationModule is ILiquidationModule {
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);
         uint128 absSize = MathUtil.abs(market.positions[accountId].size).to128();
 
+        // Return empty when a position does not exist.
         if (absSize == 0) {
-            revert ErrorUtil.PositionNotFound();
+            return (0, 0);
         }
 
         flagKeeperReward = Position.getLiquidationFlagReward(

--- a/contracts/modules/LiquidationModule.sol
+++ b/contracts/modules/LiquidationModule.sol
@@ -278,9 +278,12 @@ contract LiquidationModule is ILiquidationModule {
         uint128 accountId,
         uint128 marketId
     ) external view returns (uint256 flagKeeperReward, uint256 liqKeeperFee) {
+        Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
+
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);
+
         uint128 absSize = MathUtil.abs(market.positions[accountId].size).to128();
 
         // Return empty when a position does not exist.

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -48,8 +48,13 @@ contract MarginModule is IMarginModule {
     ) private view {
         uint256 oraclePrice = market.getOraclePrice();
 
-        // We use the haircut adjusted price here due to the explicit liquidation check.
-        uint256 marginUsd = Margin.getMarginUsd(accountId, market, oraclePrice, true /* useHaircutCollateralPrice */);
+        // We use the discount adjusted price here due to the explicit liquidation check.
+        uint256 marginUsd = Margin.getMarginUsd(
+            accountId,
+            market,
+            oraclePrice,
+            true /* useDiscountedCollateralPrice */
+        );
 
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(market.id);
 
@@ -441,7 +446,7 @@ contract MarginModule is IMarginModule {
     function getCollateralUsd(uint128 accountId, uint128 marketId) external view returns (uint256) {
         Account.exists(accountId);
         PerpMarket.exists(marketId);
-        return Margin.getCollateralUsd(accountId, marketId, false /* useHaircutCollateralPrice */);
+        return Margin.getCollateralUsd(accountId, marketId, false /* useDiscountedCollateralPrice */);
     }
 
     /**
@@ -450,15 +455,16 @@ contract MarginModule is IMarginModule {
     function getMarginUsd(uint128 accountId, uint128 marketId) external view returns (uint256) {
         Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
-        return Margin.getMarginUsd(accountId, market, market.getOraclePrice(), false /* useHaircutCollateralPrice */);
+        return
+            Margin.getMarginUsd(accountId, market, market.getOraclePrice(), false /* useDiscountedCollateralPrice */);
     }
 
     /**
      * @inheritdoc IMarginModule
      */
-    function getHaircutCollateralPrice(uint128 synthMarketId, int256 size) external view returns (uint256) {
+    function getDiscountedCollateralPrice(uint128 synthMarketId, int256 size) external view returns (uint256) {
         Margin.GlobalData storage globalMarginConfig = Margin.load();
         PerpMarketConfiguration.GlobalData storage globalMarketConfig = PerpMarketConfiguration.load();
-        return globalMarginConfig.getHaircutCollateralPrice(synthMarketId, MathUtil.abs(size), globalMarketConfig);
+        return globalMarginConfig.getDiscountedCollateralPrice(synthMarketId, MathUtil.abs(size), globalMarketConfig);
     }
 }

--- a/contracts/modules/MarginModule.sol
+++ b/contracts/modules/MarginModule.sol
@@ -462,9 +462,9 @@ contract MarginModule is IMarginModule {
     /**
      * @inheritdoc IMarginModule
      */
-    function getDiscountedCollateralPrice(uint128 synthMarketId, int256 size) external view returns (uint256) {
+    function getDiscountedCollateralPrice(uint128 synthMarketId, uint256 amount) external view returns (uint256) {
         Margin.GlobalData storage globalMarginConfig = Margin.load();
         PerpMarketConfiguration.GlobalData storage globalMarketConfig = PerpMarketConfiguration.load();
-        return globalMarginConfig.getDiscountedCollateralPrice(synthMarketId, MathUtil.abs(size), globalMarketConfig);
+        return globalMarginConfig.getDiscountedCollateralPrice(synthMarketId, amount, globalMarketConfig);
     }
 }

--- a/contracts/modules/MarketConfigurationModule.sol
+++ b/contracts/modules/MarketConfigurationModule.sol
@@ -28,6 +28,7 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         config.keeperFlagGasUnits = data.keeperFlagGasUnits;
         config.keeperLiquidationFeeUsd = data.keeperLiquidationFeeUsd;
         config.keeperLiquidationEndorsed = data.keeperLiquidationEndorsed;
+        config.spotMarketSkewScaleScalar = data.spotMarketSkewScaleScalar;
         config.minCollateralDiscount = data.minCollateralDiscount;
         config.maxCollateralDiscount = data.maxCollateralDiscount;
         config.sellExactInMaxSlippagePercent = data.sellExactInMaxSlippagePercent;

--- a/contracts/modules/MarketConfigurationModule.sol
+++ b/contracts/modules/MarketConfigurationModule.sol
@@ -28,8 +28,8 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         config.keeperFlagGasUnits = data.keeperFlagGasUnits;
         config.keeperLiquidationFeeUsd = data.keeperLiquidationFeeUsd;
         config.keeperLiquidationEndorsed = data.keeperLiquidationEndorsed;
-        config.minCollateralHaircut = data.minCollateralHaircut;
-        config.maxCollateralHaircut = data.maxCollateralHaircut;
+        config.minCollateralDiscount = data.minCollateralDiscount;
+        config.maxCollateralDiscount = data.maxCollateralDiscount;
         config.sellExactInMaxSlippagePercent = data.sellExactInMaxSlippagePercent;
         config.utilizationBreakpointPercent = data.utilizationBreakpointPercent;
         config.lowUtilizationSlopePercent = data.lowUtilizationSlopePercent;

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -286,7 +286,11 @@ contract OrderModule is IOrderModule {
         // Update collateral used for margin if necessary. We only perform this if modifying an existing position.
         if (oldPosition.size != 0) {
             // @dev We're using getCollateralUsd and not marginUsd as we dont want price changes to be deducted yet.
-            uint256 collateralUsd = Margin.getCollateralUsd(accountId, marketId, false /* usehaircutCollateralPrice */);
+            uint256 collateralUsd = Margin.getCollateralUsd(
+                accountId,
+                marketId,
+                false /* useDiscountedCollateralPrice */
+            );
             Margin.updateAccountCollateral(
                 accountId,
                 market,

--- a/contracts/modules/OrderModule.sol
+++ b/contracts/modules/OrderModule.sol
@@ -269,22 +269,19 @@ contract OrderModule is IOrderModule {
             marketConfig
         );
 
-        Position.Data storage oldPosition = market.positions[accountId];
-
-        market.skew = market.skew + runtime.trade.newPosition.size - oldPosition.size;
-        market.size = (market.size.to256() +
-            MathUtil.abs(runtime.trade.newPosition.size) -
-            MathUtil.abs(oldPosition.size)).to128();
+        market.skew = market.skew + runtime.trade.newPosition.size - position.size;
+        market.size = (market.size.to256() + MathUtil.abs(runtime.trade.newPosition.size) - MathUtil.abs(position.size))
+            .to128();
 
         // We want to validateTrade and update market size before we recompute utilisation
         // 1. The validateTrade call getMargin to figure out the new margin, this should be using the utilisation rate up to this point
         // 2. The new utlization rate is calculated using the new maret size, so we need to update the size before we recompute utilisation
         recomputeUtilization(market, runtime.pythPrice);
 
-        market.updateDebtCorrection(oldPosition, runtime.trade.newPosition);
+        market.updateDebtCorrection(position, runtime.trade.newPosition);
 
         // Update collateral used for margin if necessary. We only perform this if modifying an existing position.
-        if (oldPosition.size != 0) {
+        if (position.size != 0) {
             // @dev We're using getCollateralUsd and not marginUsd as we dont want price changes to be deducted yet.
             uint256 collateralUsd = Margin.getCollateralUsd(
                 accountId,

--- a/contracts/modules/PerpAccountModule.sol
+++ b/contracts/modules/PerpAccountModule.sol
@@ -52,7 +52,7 @@ contract PerpAccountModule is IPerpAccountModule {
         return
             IPerpAccountModule.AccountDigest(
                 depositedCollaterals,
-                Margin.getCollateralUsd(accountId, marketId, false /* useHaircutCollateralPrice */),
+                Margin.getCollateralUsd(accountId, marketId, false /* useDiscountedCollateralPrice */),
                 market.orders[accountId],
                 getPositionDigest(accountId, marketId)
             );
@@ -83,7 +83,7 @@ contract PerpAccountModule is IPerpAccountModule {
             position.entryPrice,
             position.entryFundingAccrued,
             position.entryUtilizationAccrued,
-            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useHaircutCollateralPrice */),
+            Margin.getMarginUsd(accountId, market, oraclePrice, true /* useDiscountedCollateralPrice */),
             oraclePrice,
             marketConfig
         );

--- a/contracts/modules/PerpMarketFactoryModule.sol
+++ b/contracts/modules/PerpMarketFactoryModule.sol
@@ -43,9 +43,7 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
      */
     function setSpotMarket(ISpotMarketSystem spotMarket) external {
         OwnableStorage.onlyOwner();
-        PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
-
-        globalConfig.spotMarket = spotMarket;
+        PerpMarketConfiguration.load().spotMarket = spotMarket;
     }
 
     /**
@@ -53,8 +51,7 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
      */
     function setPyth(IPyth pyth) external {
         OwnableStorage.onlyOwner();
-        PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
-        globalConfig.pyth = pyth;
+        PerpMarketConfiguration.load().pyth = pyth;
     }
 
     /**
@@ -62,8 +59,7 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
      */
     function setEthOracleNodeId(bytes32 ethOracleNodeId) external {
         OwnableStorage.onlyOwner();
-        PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
-        globalConfig.ethOracleNodeId = ethOracleNodeId;
+        PerpMarketConfiguration.load().ethOracleNodeId = ethOracleNodeId;
     }
 
     /**
@@ -71,8 +67,7 @@ contract PerpMarketFactoryModule is IPerpMarketFactoryModule {
      */
     function setRewardDistributorImplementation(address implementation) external {
         OwnableStorage.onlyOwner();
-        PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
-        globalConfig.rewardDistributorImplementation = implementation;
+        PerpMarketConfiguration.load().rewardDistributorImplementation = implementation;
     }
 
     /**

--- a/contracts/storage/Margin.sol
+++ b/contracts/storage/Margin.sol
@@ -311,7 +311,7 @@ library Margin {
 
         // Calculate discount on collateral if this collateral were to be instantly sold on spot.
         uint256 price = getOracleCollateralPrice(self, synthMarketId, globalConfig);
-        uint256 skewScale = globalConfig.spotMarket.getMarketSkewScale(synthMarketId);
+        uint256 skewScale = globalConfig.spotMarket.getMarketSkewScale(synthMarketId) * 2;
 
         // skewScale _may_ be zero. In this event, do _not_ apply a discount.
         uint256 discount = skewScale == 0

--- a/contracts/storage/Margin.sol
+++ b/contracts/storage/Margin.sol
@@ -311,7 +311,7 @@ library Margin {
 
         // Calculate discount on collateral if this collateral were to be instantly sold on spot.
         uint256 price = getOracleCollateralPrice(self, synthMarketId, globalConfig);
-        uint256 skewScale = globalConfig.spotMarket.getMarketSkewScale(synthMarketId) * 2;
+        uint256 skewScale = globalConfig.spotMarket.getMarketSkewScale(synthMarketId).mulDecimal(globalConfig.spotMarketSkewScaleScalar);
 
         // skewScale _may_ be zero. In this event, do _not_ apply a discount.
         uint256 discount = skewScale == 0

--- a/contracts/storage/Margin.sol
+++ b/contracts/storage/Margin.sol
@@ -270,6 +270,10 @@ library Margin {
 
     // --- Member (views) --- //
 
+    /**
+     * @dev Helper to call oraclerManager.process on a given `synthMarketId`. Note that this can result in errors
+     * if the `synthMarketId` does not exist.
+     */
     function getOracleCollateralPrice(
         Margin.GlobalData storage self,
         uint128 synthMarketId,

--- a/contracts/storage/PerpMarketConfiguration.sol
+++ b/contracts/storage/PerpMarketConfiguration.sol
@@ -58,6 +58,8 @@ library PerpMarketConfiguration {
         uint256 keeperLiquidationFeeUsd;
         // Address of endorsed liquidation keeper to exceed liq caps.
         address keeperLiquidationEndorsed;
+        // A scalar applied on the spot market skewScale for collateral discount adjustment.
+        uint128 spotMarketSkewScaleScalar;
         // Minimum discount applied on deposited margin collateral.
         uint128 minCollateralDiscount;
         // Maximum discount applied on deposited margin collateral.

--- a/contracts/storage/PerpMarketConfiguration.sol
+++ b/contracts/storage/PerpMarketConfiguration.sol
@@ -58,10 +58,10 @@ library PerpMarketConfiguration {
         uint256 keeperLiquidationFeeUsd;
         // Address of endorsed liquidation keeper to exceed liq caps.
         address keeperLiquidationEndorsed;
-        // Minimum haircut applied on deposited margin collateral.
-        uint128 minCollateralHaircut;
-        // Maximum haircut applied on deposited margin collateral.
-        uint128 maxCollateralHaircut;
+        // Minimum discount applied on deposited margin collateral.
+        uint128 minCollateralDiscount;
+        // Maximum discount applied on deposited margin collateral.
+        uint128 maxCollateralDiscount;
         // Maximum slippage on collateral sold for negative pnl position modifications.
         uint128 sellExactInMaxSlippagePercent;
         // Dictates wheter or not the utilization rate should use high or low slope

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -7,7 +7,7 @@ import { PerpMarketProxy, PerpAccountProxy, AggregatorV3Mock, PythMock } from '.
 import { CollateralMock, SettlementHookMock } from '../typechain-types';
 import { bn, genOneOf } from './generators';
 import { bootstrapSynthMarkets } from './external/bootstrapSynthMarkets';
-import { ADDRESS0, SYNTHETIX_USD_MARKET_ID } from './helpers';
+import { ADDRESS0, SYNTHETIX_USD_MARKET_ID, sleep } from './helpers';
 import { formatBytes32String } from 'ethers/lib/utils';
 import type { WstETHMock } from '../typechain-types/contracts/mocks/WstETHMock';
 import { GeneratedBootstrap } from './typed';
@@ -149,6 +149,11 @@ export const bootstrap = (args: GeneratedBootstrap) => {
     })),
     stakedPool
   );
+
+  before('wait for core bootstrap, pools, and synth markets...', async () => {
+    await sleep(1000);
+  });
+
   const getConfiguredSynths = () =>
     _COLLATERALS_TO_CONFIGURE.map((collateral, i) => ({ ...collateral, synthMarket: spotMarket.synthMarkets()[i] }));
 

--- a/test/calculations.ts
+++ b/test/calculations.ts
@@ -166,16 +166,18 @@ export const calcDiscountedCollateralPrice = (
   collateralPrice: BigNumber,
   amount: BigNumber,
   spotMarketSkewScale: BigNumber,
+  spotMarketSkewScaleScalar: BigNumber,
   min: BigNumber,
   max: BigNumber
 ) => {
   const w_collateralPrice = wei(collateralPrice);
   const w_amount = wei(amount);
   const w_spotMarketSkewScale = wei(spotMarketSkewScale);
+  const w_spotMarketSkewScaleScalar = wei(spotMarketSkewScaleScalar);
   const w_min = wei(min);
   const w_max = wei(max);
 
-  // price = oraclePrice * (1 - min(max(size / (skewScale * 2), minCollateralDiscount), maxCollateralDiscount))
-  const discount = Wei.min(Wei.max(w_amount.div(w_spotMarketSkewScale.mul(wei(2))), w_min), w_max);
+  // price = oraclePrice * (1 - min(max(size / (skewScale * skewScaleScalar), minCollateralDiscount), maxCollateralDiscount))
+  const discount = Wei.min(Wei.max(w_amount.div(w_spotMarketSkewScale.mul(w_spotMarketSkewScaleScalar)), w_min), w_max);
   return w_collateralPrice.mul(wei(1).sub(discount)).toBN();
 };

--- a/test/calculations.ts
+++ b/test/calculations.ts
@@ -2,6 +2,21 @@ import { BigNumber } from 'ethers';
 import Wei, { wei } from '@synthetixio/wei';
 import type { Bs } from './typed';
 import { PerpMarketConfiguration } from './generated/typechain/MarketConfigurationModule';
+import { bn } from './generators';
+
+// --- Primitives --- //
+
+const divDecimalAndCeil = (a: Wei, b: Wei) => {
+  const x = wei(a).toNumber() / wei(b).toNumber();
+  return wei(Math.ceil(x));
+};
+
+// --- Domain --- //
+
+/** Calculates whether two numbers are the same sign. */
+export const isSameSide = (a: Wei | BigNumber, b: Wei | BigNumber) => a.eq(0) || b.eq(0) || a.gt(0) == b.gt(0);
+
+// --- Calcs --- //
 
 /** Calculates a position's unrealised PnL (no funding or fees) given the current and previous price. */
 export const calcPnl = (size: BigNumber, currentPrice: BigNumber, previousPrice: BigNumber) =>
@@ -23,9 +38,6 @@ export const calcFillPrice = (skew: BigNumber, skewScale: BigNumber, size: BigNu
 
   return priceBefore.add(priceAfter).div(2).toBN();
 };
-
-/** Calculates whether two numbers are the same sign. */
-export const isSameSide = (a: Wei | BigNumber, b: Wei | BigNumber) => a.eq(0) || b.eq(0) || a.gt(0) == b.gt(0);
 
 /** Calculates order fees and keeper fees associated to settle the order. */
 export const calcOrderFees = async (
@@ -91,7 +103,7 @@ export const calcOrderFees = async (
   return { notional, orderFee, calcKeeperOrderSettlementFee };
 };
 
-export const calculateTransactionCostInUsd = (
+export const calcTransactionCostInUsd = (
   baseFeePerGas: BigNumber, // in gwei
   gasUnitsForTx: BigNumber, // in gwei
   ethPrice: BigNumber // in ether
@@ -100,7 +112,8 @@ export const calculateTransactionCostInUsd = (
   return costInGwei.mul(ethPrice).div(BigNumber.from(10).pow(18));
 };
 
-export const calculateFlagReward = (
+/** Calculates the in USD, the reward to flag a position for liquidation. */
+export const calcFlagReward = (
   ethPrice: BigNumber,
   baseFeePerGas: BigNumber, // in gwei
   sizeAbs: Wei,
@@ -108,11 +121,7 @@ export const calculateFlagReward = (
   globalConfig: PerpMarketConfiguration.GlobalDataStructOutput,
   marketConfig: PerpMarketConfiguration.DataStructOutput
 ) => {
-  const flagExecutionCostInUsd = calculateTransactionCostInUsd(
-    baseFeePerGas,
-    globalConfig.keeperFlagGasUnits,
-    ethPrice
-  );
+  const flagExecutionCostInUsd = calcTransactionCostInUsd(baseFeePerGas, globalConfig.keeperFlagGasUnits, ethPrice);
 
   const flagFeeInUsd = Wei.max(
     wei(flagExecutionCostInUsd).mul(wei(1).add(globalConfig.keeperProfitMarginPercent)),
@@ -129,11 +138,9 @@ export const calculateFlagReward = (
     flagFeeInUsd,
   };
 };
-const divDecimalAndCeil = (a: Wei, b: Wei) => {
-  const x = wei(a).toNumber() / wei(b).toNumber();
-  return wei(Math.ceil(x));
-};
-export const calculateLiquidationKeeperFee = (
+
+/** Calculates the liquidation fees in USD given price of ETH, gas, size of position and capacity. */
+export const calcLiquidationKeeperFee = (
   ethPrice: BigNumber,
   baseFeePerGas: BigNumber, // in gwei
   sizeAbs: Wei,
@@ -144,7 +151,7 @@ export const calculateLiquidationKeeperFee = (
   const iterations = divDecimalAndCeil(sizeAbs, maxLiqCapacity);
 
   const totalGasUnitsToLiquidate = wei(globalConfig.keeperLiquidationGasUnits).toBN();
-  const flagExecutionCostInUsd = calculateTransactionCostInUsd(baseFeePerGas, totalGasUnitsToLiquidate, ethPrice);
+  const flagExecutionCostInUsd = calcTransactionCostInUsd(baseFeePerGas, totalGasUnitsToLiquidate, ethPrice);
 
   const liquidationFeeInUsd = Wei.max(
     wei(flagExecutionCostInUsd).mul(wei(1).add(globalConfig.keeperProfitMarginPercent)),
@@ -152,4 +159,23 @@ export const calculateLiquidationKeeperFee = (
   );
 
   return Wei.min(liquidationFeeInUsd, wei(globalConfig.maxKeeperFeeUsd)).mul(iterations);
+};
+
+/** Calculates the discounted collateral price given the size, spot market skew scale, and min/max discounts. */
+export const calcDiscountedCollateralPrice = (
+  collateralPrice: BigNumber,
+  amount: BigNumber,
+  spotMarketSkewScale: BigNumber,
+  min: BigNumber,
+  max: BigNumber
+) => {
+  const w_collateralPrice = wei(collateralPrice);
+  const w_amount = wei(amount);
+  const w_spotMarketSkewScale = wei(spotMarketSkewScale);
+  const w_min = wei(min);
+  const w_max = wei(max);
+
+  // price = oraclePrice * (1 - min(max(size / (skewScale * 2), minCollateralDiscount), maxCollateralDiscount))
+  const discount = Wei.min(Wei.max(w_amount.div(w_spotMarketSkewScale.mul(wei(2))), w_min), w_max);
+  return w_collateralPrice.mul(wei(1).sub(discount)).toBN();
 };

--- a/test/external/bootstrapSynthMarkets.ts
+++ b/test/external/bootstrapSynthMarkets.ts
@@ -38,7 +38,7 @@ export type BootstrapSynthArgs = {
 export function bootstrapSynthMarkets(data: BootstrapSynthArgs, r: ReturnType<typeof createStakedPool>) {
   let contracts: Systems, marketOwner: ethers.Signer;
 
-  before('identify actors', () => {
+  before('identify actors', async () => {
     contracts = r.systems() as unknown as Systems;
     [, , marketOwner] = r.signers();
   });

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -80,8 +80,8 @@ export const genBootstrap = () => ({
     keeperLiquidationGasUnits: 1_200_000,
     keeperLiquidationFeeUsd: bn(genNumber(1, 5)),
     keeperLiquidationEndorsed: genAddress(), // Temporary dummy address to be reconfigurd later.
-    minCollateralHaircut: bn(0.01),
-    maxCollateralHaircut: bn(0.05),
+    minCollateralDiscount: bn(0.01),
+    maxCollateralDiscount: bn(0.05),
     sellExactInMaxSlippagePercent: bn(genNumber(0.03, 0.05)),
     utilizationBreakpointPercent: bn(genNumber(0.65, 0.85)),
     lowUtilizationSlopePercent: bn(genNumber(0.0002, 0.0003)),

--- a/test/generators.ts
+++ b/test/generators.ts
@@ -80,6 +80,7 @@ export const genBootstrap = () => ({
     keeperLiquidationGasUnits: 1_200_000,
     keeperLiquidationFeeUsd: bn(genNumber(1, 5)),
     keeperLiquidationEndorsed: genAddress(), // Temporary dummy address to be reconfigurd later.
+    spotMarketSkewScaleScalar: bn(1),
     minCollateralDiscount: bn(0.01),
     maxCollateralDiscount: bn(0.05),
     sellExactInMaxSlippagePercent: bn(genNumber(0.03, 0.05)),

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -37,7 +37,7 @@ import {
 } from '../../helpers';
 import { Market, Trader } from '../../typed';
 import { assertEvents } from '../../assert';
-import { calculateLiquidationKeeperFee, calculateTransactionCostInUsd } from '../../calculations';
+import { calcLiquidationKeeperFee, calcTransactionCostInUsd } from '../../calculations';
 
 describe('LiquidationModule', () => {
   const bs = bootstrap(genBootstrap());
@@ -1611,7 +1611,7 @@ describe('LiquidationModule', () => {
         const { liqKeeperFee } = await PerpMarketProxy.getLiquidationFees(trader.accountId, marketId);
 
         const { answer: ethPrice } = await bs.ethOracleNode().agg.latestRoundData();
-        const expectedLiqFee = calculateLiquidationKeeperFee(
+        const expectedLiqFee = calcLiquidationKeeperFee(
           ethPrice,
           baseFeePerGas,
           wei(order.sizeDelta).abs(),
@@ -1749,14 +1749,14 @@ describe('LiquidationModule', () => {
           PerpMarketProxy
         ).args;
         const sizeAbsUsd = wei(order.sizeDelta).abs().mul(flaggedPrice);
-        const expectedCostFlag = calculateTransactionCostInUsd(baseFeePerGas, keeperFlagGasUnits, ethPrice);
+        const expectedCostFlag = calcTransactionCostInUsd(baseFeePerGas, keeperFlagGasUnits, ethPrice);
         const expectedFlagReward = wei(expectedCostFlag)
           .mul(wei(1).add(keeperProfitMarginPercent))
           .add(sizeAbsUsd.mul(flagRewardPercent));
 
         assertBn.equal(flagKeeperReward, expectedFlagReward.toBN());
 
-        const expectedCostLiq = calculateTransactionCostInUsd(baseFeePerGas, keeperLiquidationGasUnits, ethPrice);
+        const expectedCostLiq = calcTransactionCostInUsd(baseFeePerGas, keeperLiquidationGasUnits, ethPrice);
         const expectedKeeperFee = wei(expectedCostLiq).mul(wei(1).add(keeperProfitMarginPercent));
 
         assertBn.equal(liqKeeperFee, wei(expectedKeeperFee).toBN());
@@ -1824,14 +1824,14 @@ describe('LiquidationModule', () => {
         ).args;
         const { liqKeeperFee } = findEventSafe(liqReceipt, 'PositionLiquidated', PerpMarketProxy).args;
         const sizeAbsUsd = wei(order.sizeDelta).abs().mul(flaggedPrice);
-        const expectedCostFlag = calculateTransactionCostInUsd(baseFeePerGas, keeperFlagGasUnits, ethPrice);
+        const expectedCostFlag = calcTransactionCostInUsd(baseFeePerGas, keeperFlagGasUnits, ethPrice);
         const expectedFlagReward = wei(expectedCostFlag)
           .add(wei(keeperProfitMarginUsd))
           .add(sizeAbsUsd.mul(flagRewardPercent));
 
         assertBn.equal(flagKeeperReward, expectedFlagReward.toBN());
 
-        const expectedCostLiq = calculateTransactionCostInUsd(baseFeePerGas, keeperLiquidationGasUnits, ethPrice);
+        const expectedCostLiq = calcTransactionCostInUsd(baseFeePerGas, keeperLiquidationGasUnits, ethPrice);
         const expectedKeeperFee = wei(expectedCostLiq).add(wei(keeperProfitMarginUsd));
 
         assertBn.equal(liqKeeperFee, wei(expectedKeeperFee).toBN());

--- a/test/integration/modules/LiquidationModule.test.ts
+++ b/test/integration/modules/LiquidationModule.test.ts
@@ -993,6 +993,16 @@ describe('LiquidationModule', () => {
       );
     });
 
+    describe('getLiquidationFees', () => {
+      it('should revert when accountId does not exist');
+
+      it('should revert when marketId does not exist');
+
+      it('should return zero when accountId/marketId exists but no position');
+
+      it('should return the expected liquidationFees on an open position');
+    });
+
     describe('getRemainingLiquidatableSizeCapacity', () => {
       const calcMaxLiquidatableCapacity = (
         makerFee: BigNumber,

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -2309,7 +2309,5 @@ describe('MarginModule', async () => {
 
       assertBn.equal(collateralPricePos, collateralPriceNeg);
     });
-
-    it('should revert when synthMarketId does not exist');
   });
 });

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -2263,10 +2263,14 @@ describe('MarginModule', async () => {
       const collateralPrice = await collateral.getPrice();
 
       const maxCollateralDiscount = bn(0.02);
-      await setMarketConfiguration(bs, { minCollateralDiscount: bn(0.01), maxCollateralDiscount });
+      await setMarketConfiguration(bs, {
+        minCollateralDiscount: bn(0.01),
+        maxCollateralDiscount,
+        spotMarketSkewScaleScalar: bn(2),
+      });
       await SpotMarket.connect(spotMarket.marketOwner()).setMarketSkewScale(collateral.synthMarketId(), bn(500_000));
 
-      // price = oraclePrice * (1 - min(max(amount / (skewScale * 2), minCollateralDiscount), maxCollateralDiscount))
+      // price = oraclePrice * (1 - min(max(amount / (skewScale * spotMarketSkewScaleScalar), minCollateralDiscount), maxCollateralDiscount))
       //
       // 30k / (500k * 2) = 0.03 (bounded by max is 0.02).
       const amount = bn(30_000);
@@ -2284,10 +2288,14 @@ describe('MarginModule', async () => {
       const collateralPrice = await collateral.getPrice();
 
       const minCollateralDiscount = bn(0.01);
-      await setMarketConfiguration(bs, { minCollateralDiscount, maxCollateralDiscount: bn(0.2) });
+      await setMarketConfiguration(bs, {
+        minCollateralDiscount,
+        maxCollateralDiscount: bn(0.2),
+        spotMarketSkewScaleScalar: bn(2),
+      });
       await SpotMarket.connect(spotMarket.marketOwner()).setMarketSkewScale(collateral.synthMarketId(), bn(500_000));
 
-      // price = oraclePrice * (1 - min(max(amount / (skewScale * 2), minCollateralDiscount), maxCollateralDiscount))
+      // price = oraclePrice * (1 - min(max(amount / (skewScale * spotMarketSkewScaleScalar), minCollateralDiscount), maxCollateralDiscount))
       //
       // 500 / (500k * 2) = 0.0005 (bounded by min is 0.01).
       const amount = bn(500);
@@ -2306,7 +2314,8 @@ describe('MarginModule', async () => {
 
       const minCollateralDiscount = bn(0.0001);
       const maxCollateralDiscount = bn(0.99);
-      await setMarketConfiguration(bs, { minCollateralDiscount, maxCollateralDiscount });
+      const spotMarketSkewScaleScalar = bn(2);
+      await setMarketConfiguration(bs, { minCollateralDiscount, maxCollateralDiscount, spotMarketSkewScaleScalar });
 
       const spotMarketSkewScale = bn(500_000);
       await SpotMarket.connect(spotMarket.marketOwner()).setMarketSkewScale(
@@ -2319,6 +2328,7 @@ describe('MarginModule', async () => {
         collateralPrice,
         amount,
         spotMarketSkewScale,
+        spotMarketSkewScaleScalar,
         minCollateralDiscount,
         maxCollateralDiscount
       );

--- a/test/integration/modules/MarginModule.test.ts
+++ b/test/integration/modules/MarginModule.test.ts
@@ -2309,5 +2309,7 @@ describe('MarginModule', async () => {
 
       assertBn.equal(collateralPricePos, collateralPriceNeg);
     });
+
+    it('should revert when synthMarketId does not exist');
   });
 });

--- a/test/integration/modules/MarketConfigurationModule.test.ts
+++ b/test/integration/modules/MarketConfigurationModule.test.ts
@@ -34,8 +34,8 @@ describe('MarketConfigurationModule', async () => {
       assert.equal(config.keeperSettlementGasUnits, global.keeperSettlementGasUnits);
       assert.equal(config.keeperLiquidationGasUnits, global.keeperLiquidationGasUnits);
       assertBn.equal(config.keeperLiquidationFeeUsd, global.keeperLiquidationFeeUsd);
-      assertBn.equal(config.minCollateralHaircut, global.minCollateralHaircut);
-      assertBn.equal(config.maxCollateralHaircut, global.maxCollateralHaircut);
+      assertBn.equal(config.minCollateralDiscount, global.minCollateralDiscount);
+      assertBn.equal(config.maxCollateralDiscount, global.maxCollateralDiscount);
       assertBn.equal(config.sellExactInMaxSlippagePercent, global.sellExactInMaxSlippagePercent);
       assertBn.equal(config.utilizationBreakpointPercent, global.utilizationBreakpointPercent);
       assertBn.equal(config.lowUtilizationSlopePercent, global.lowUtilizationSlopePercent);

--- a/test/integration/modules/MarketConfigurationModule.test.ts
+++ b/test/integration/modules/MarketConfigurationModule.test.ts
@@ -34,6 +34,7 @@ describe('MarketConfigurationModule', async () => {
       assert.equal(config.keeperSettlementGasUnits, global.keeperSettlementGasUnits);
       assert.equal(config.keeperLiquidationGasUnits, global.keeperLiquidationGasUnits);
       assertBn.equal(config.keeperLiquidationFeeUsd, global.keeperLiquidationFeeUsd);
+      assertBn.equal(config.spotMarketSkewScaleScalar, global.spotMarketSkewScaleScalar);
       assertBn.equal(config.minCollateralDiscount, global.minCollateralDiscount);
       assertBn.equal(config.maxCollateralDiscount, global.maxCollateralDiscount);
       assertBn.equal(config.sellExactInMaxSlippagePercent, global.sellExactInMaxSlippagePercent);

--- a/test/integration/modules/OrderModule.cancel.test.ts
+++ b/test/integration/modules/OrderModule.cancel.test.ts
@@ -260,7 +260,7 @@ describe('OrderModule Cancelations', () => {
         .mockSetCurrentPrice(orderSide === 1 ? order.limitPrice.add(1) : order.limitPrice.sub(1));
 
       // Fees are calculated against the discounted collateral value. Do not discount the collateral.
-      await setMarketConfiguration(bs, { minCollateralHaircut: bn(0), maxCollateralHaircut: bn(0) });
+      await setMarketConfiguration(bs, { minCollateralDiscount: bn(0), maxCollateralDiscount: bn(0) });
 
       const { publishTime, settlementTime } = await getFastForwardTimestamp(bs, marketId, trader);
       await fastForwardTo(settlementTime, provider());

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -1799,16 +1799,44 @@ describe('OrderModule', () => {
   });
 
   describe('getOrderDigest', () => {
-    it('should revert when accountId does not exist');
+    it('should revert when accountId does not exist', async () => {
+      const { PerpMarketProxy } = systems();
 
-    it('should revert when marketId does not exist');
+      const market = genOneOf(markets());
+      const invalidAccountId = 42069;
 
-    it('should return default object when accountId/marketId exists but no order');
+      await assertRevert(
+        PerpMarketProxy.getOrderDigest(invalidAccountId, market.marketId()),
+        `AccountNotFound("${invalidAccountId}")`,
+        PerpMarketProxy
+      );
+    });
+
+    it('should revert when marketId does not exist', async () => {
+      const { PerpMarketProxy } = systems();
+
+      const trader = genOneOf(traders());
+      const invalidMarketId = 42069;
+
+      await assertRevert(
+        PerpMarketProxy.getOrderDigest(trader.accountId, invalidMarketId),
+        `MarketNotFound("${invalidMarketId}")`,
+        PerpMarketProxy
+      );
+    });
+
+    it('should return default object when accountId/marketId exists but no order', async () => {
+      const { PerpMarketProxy } = systems();
+
+      const trader = genOneOf(traders());
+      const market = genOneOf(markets());
+
+      const { sizeDelta } = await PerpMarketProxy.getOrderDigest(trader.accountId, market.marketId());
+      assertBn.isZero(sizeDelta);
+    });
   });
 
   describe('getOrderFees', () => {
-    it('should revert when marketId does not exist');
-
     describe('orderFee', () => {
       enum LiquidtyLeader {
         MAKER = 'MAKER',
@@ -1968,6 +1996,17 @@ describe('OrderModule', () => {
         const takerFeeUsd = wei(order1.sizeDelta.abs()).mul(order2.fillPrice).mul(takerFee);
 
         assertBn.equal(orderFee2, makerFeeUsd.add(takerFeeUsd).toBN());
+      });
+
+      it('should revert when marketId does not exist', async () => {
+        const { PerpMarketProxy } = systems();
+
+        const invalidMarketId = 42069;
+        await assertRevert(
+          PerpMarketProxy.getOrderFees(invalidMarketId, bn(0), bn(0)),
+          `MarketNotFound("${invalidMarketId}")`,
+          PerpMarketProxy
+        );
       });
     });
 
@@ -2183,6 +2222,15 @@ describe('OrderModule', () => {
   });
 
   describe('getOraclePrice', () => {
-    it('should revert when marketId does not exist');
+    it('should revert when marketId does not exist', async () => {
+      const { PerpMarketProxy } = systems();
+
+      const invalidMarketId = 42069;
+      await assertRevert(
+        PerpMarketProxy.getOraclePrice(invalidMarketId),
+        `MarketNotFound("${invalidMarketId}")`,
+        PerpMarketProxy
+      );
+    });
   });
 });

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -1300,8 +1300,8 @@ describe('OrderModule', () => {
         // A low slippage tolerance results in a revert on the position modify.
         await setMarketConfiguration(bs, {
           sellExactInMaxSlippagePercent: bn(0.00001),
-          maxCollateralHaircut: bn(0),
-          minCollateralHaircut: bn(0),
+          maxCollateralDiscount: bn(0),
+          minCollateralDiscount: bn(0),
         });
         await SpotMarket.connect(spotMarket.marketOwner()).setMarketSkewScale(
           collateral.synthMarketId(),

--- a/test/integration/modules/OrderModule.test.ts
+++ b/test/integration/modules/OrderModule.test.ts
@@ -1798,7 +1798,17 @@ describe('OrderModule', () => {
     });
   });
 
+  describe('getOrderDigest', () => {
+    it('should revert when accountId does not exist');
+
+    it('should revert when marketId does not exist');
+
+    it('should return default object when accountId/marketId exists but no order');
+  });
+
   describe('getOrderFees', () => {
+    it('should revert when marketId does not exist');
+
     describe('orderFee', () => {
       enum LiquidtyLeader {
         MAKER = 'MAKER',
@@ -2066,7 +2076,7 @@ describe('OrderModule', () => {
   });
 
   describe('getFillPrice', () => {
-    it('should revert invalid market id', async () => {
+    it('should revert when marketId does not exist', async () => {
       const { PerpMarketProxy } = systems();
       const invalidMarketId = bn(42069);
 
@@ -2170,5 +2180,9 @@ describe('OrderModule', () => {
 
       assertBn.equal(expectedFillPrice, actualFillPrice);
     });
+  });
+
+  describe('getOraclePrice', () => {
+    it('should revert when marketId does not exist');
   });
 });

--- a/test/integration/modules/PerpAccountModule.test.ts
+++ b/test/integration/modules/PerpAccountModule.test.ts
@@ -4,7 +4,7 @@ import { bootstrap } from '../../bootstrap';
 import { bn, genBootstrap, genNumber, genOneOf } from '../../generators';
 import { fastForwardBySec } from '../../helpers';
 
-describe.only('PerpAccountModule', () => {
+describe('PerpAccountModule', () => {
   const bs = bootstrap(genBootstrap());
   const { markets, traders, systems, provider, restore } = bs;
 

--- a/test/integration/modules/PerpAccountModule.test.ts
+++ b/test/integration/modules/PerpAccountModule.test.ts
@@ -1,5 +1,68 @@
-describe('PerpAccountModule', () => {
+import { BigNumber, ethers, utils } from 'ethers';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
+import { wei } from '@synthetixio/wei';
+import assert from 'assert';
+import { shuffle } from 'lodash';
+import forEach from 'mocha-each';
+import { PerpCollateral, bootstrap } from '../../bootstrap';
+import {
+  bn,
+  genBootstrap,
+  genNumber,
+  genListOf,
+  genOneOf,
+  genTrader,
+  genOrder,
+  toRoundRobinGenerators,
+  genBytes32,
+  genAddress,
+} from '../../generators';
+import {
+  mintAndApproveWithTrader,
+  commitAndSettle,
+  commitOrder,
+  depositMargin,
+  extendContractAbi,
+  fastForwardBySec,
+  findEventSafe,
+  mintAndApprove,
+  ADDRESS0,
+  withExplicitEvmMine,
+  getSusdCollateral,
+  isSusdCollateral,
+  SYNTHETIX_USD_MARKET_ID,
+  findOrThrow,
+  setMarketConfiguration,
+  SECONDS_ONE_DAY,
+  setMarketConfigurationById,
+} from '../../helpers';
+import { calcPnl } from '../../calculations';
+import { assertEvents } from '../../assert';
+
+describe.only('PerpAccountModule', () => {
+  const bs = bootstrap(genBootstrap());
+  const { markets, collaterals, collateralsWithoutSusd, spotMarket, traders, owner, systems, provider, restore } = bs;
+
+  beforeEach(restore);
+
+  describe('getAccountDigest', async () => {
+    it('should revert when accountId does not exist');
+
+    it('should revert when marketId does not exist');
+
+    it('should not revert when accountId/marketId exists but no positions are open');
+  });
+
   describe('getPositionDigest', () => {
+    it('should revert when accountId does not exist');
+
+    it('should revert when marketId does not exist');
+
+    it('should return default object when accountId/marketId exists but no position');
+
     describe('accruedFunding', () => {
       it('should accrue funding when position is opposite of skew');
 

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -551,10 +551,10 @@ describe('PerpMarketFactoryModule', () => {
     it('should report usd value of margin as report when depositing into system', async () => {
       const { PerpMarketProxy } = systems();
 
-      // Remove any collateral haircut to minimise subtle differences in deposit values.
+      // Remove any collateral discount to minimise subtle differences in deposit values.
       await setMarketConfiguration(bs, {
-        minCollateralHaircut: bn(0),
-        maxCollateralHaircut: bn(0),
+        minCollateralDiscount: bn(0),
+        maxCollateralDiscount: bn(0),
       });
 
       const { market, marginUsdDepositAmount } = await depositMargin(bs, genTrader(bs));
@@ -640,8 +640,8 @@ describe('PerpMarketFactoryModule', () => {
       await setMarketConfiguration(bs, {
         keeperProfitMarginPercent: bn(0),
         maxKeeperFeeUsd: bn(0),
-        minCollateralHaircut: bn(0),
-        maxCollateralHaircut: bn(0),
+        minCollateralDiscount: bn(0),
+        maxCollateralDiscount: bn(0),
       });
 
       await market.aggregator().mockSetCurrentPrice(bn(2000));

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -159,6 +159,8 @@ describe('PerpMarketFactoryModule', () => {
   });
 
   describe('getMarketDigest', () => {
+    it('should revert when marketId does not exist');
+
     describe('{fundingRate,fundingVelocity}', () => {
       const depositMarginToTraders = async (
         traders: Trader[],
@@ -876,5 +878,7 @@ describe('PerpMarketFactoryModule', () => {
     it('should incur no debt in a delta neutral market with high when price volatility');
 
     it('should incur small debt proportional to skew with high price volatility');
+
+    it('should revert when marketId does not exist');
   });
 });

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -159,7 +159,17 @@ describe('PerpMarketFactoryModule', () => {
   });
 
   describe('getMarketDigest', () => {
-    it('should revert when marketId does not exist');
+    it('should revert when marketId does not exist', async () => {
+      const { PerpMarketProxy } = systems();
+
+      const invalidMarketId = bn(genNumber(42069, 50_000));
+
+      await assertRevert(
+        PerpMarketProxy.getMarketDigest(invalidMarketId),
+        `MarketNotFound("${invalidMarketId}")`,
+        PerpMarketProxy
+      );
+    });
 
     describe('{fundingRate,fundingVelocity}', () => {
       const depositMarginToTraders = async (

--- a/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -180,6 +180,7 @@ describe('PerpMarketFactoryModule', () => {
           );
         }
       };
+
       it('should have 0 velocity if skew is small enough', async () => {
         const { PerpMarketProxy } = systems();
         const market = genOneOf(markets());
@@ -231,6 +232,7 @@ describe('PerpMarketFactoryModule', () => {
 
         assertBn.equal(fundingVelocity1, 0);
       });
+
       it('should compute current funding rate relative to time (concrete)', async () => {
         // This test is pulled directly from a concrete example developed for PerpsV2.
         //
@@ -879,6 +881,14 @@ describe('PerpMarketFactoryModule', () => {
 
     it('should incur small debt proportional to skew with high price volatility');
 
-    it('should revert when marketId does not exist');
+    it('should revert when marketId does not exist', async () => {
+      const { PerpMarketProxy } = systems();
+      const invalidMarketId = 42069;
+      await assertRevert(
+        PerpMarketProxy.reportedDebt(invalidMarketId),
+        `MarketNotFound("${invalidMarketId}")`,
+        PerpMarketProxy
+      );
+    });
   });
 });


### PR DESCRIPTION
- Renames haircut -> discount
- Consistency around when we revert on views (only when marketId and accountId are missing)
- `getDiscountedCollateralPrice` doesn't take a size, it accepts a `uint amount`
- Adds `spotMarketSkewScaleScalar`
- `settleOrder` doesn't load `market.positions[accountId]` twice
- More docs, more tests